### PR TITLE
Make build cards full-width on mobile

### DIFF
--- a/resources/allure-index.html
+++ b/resources/allure-index.html
@@ -122,7 +122,7 @@
     html.dark .pill-in-progress { background: rgba(255,193,7,0.15); color: #ffd54f; border-color: rgba(255,193,7,0.4); }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
 
-    @media (max-width: 640px) { .meta { display: none; } .card { padding: 0.75rem 1rem; gap: 0.75rem; } .info-top { flex-wrap: wrap; gap: 6px; align-items: flex-start; } .pill { margin-left: 0; } }
+    @media (max-width: 640px) { .meta { display: none; } .card { padding: 0.75rem 1rem; gap: 0.75rem; } .info-top { flex-wrap: wrap; gap: 6px; align-items: flex-start; } .pill { margin-left: 0; } .main { padding: 0 0.25rem 3rem; } .card { padding: 1rem; border-radius: 0; border-left: none; border-right: none; margin-bottom: 0; } .card + .card { border-top: none; } }
 
     /* View toggle */
     .view-toggle { position: fixed; top: 1rem; right: 3.25rem; display: flex; gap: 2px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 2px; z-index: 50; box-shadow: var(--shadow); }


### PR DESCRIPTION
## Problem
On mobile, build cards had rounded corners and side padding, not using full screen width effectively.

## Solution
- Changed cards to full-width (border-radius: 0 on mobile)
- Removed side borders for seamless full-width
- Connected adjacent cards (border-top: none on consecutive cards)
- Reduced main padding to 0.25rem for near-full-width

## Visual Change
Cards now look like a proper mobile list, occupying full width.

## Testing
Tested with `spel open` in iPhone 14 viewport.