### PR TITLE
feat: add PR reports to builds list on landing page

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -112,18 +112,24 @@ jobs:
             (require '[com.blockether.spel.allure-reporter :as r])
             (r/generate-html-report! \"allure-results\" \"allure-report\")"
 
+      - name: Extract test counts from Allure results
+        id: test-counts
+        run: |
+          PASSED=$(grep -l '"status": *"passed"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
+          FAILED=$(grep -l '"status": *"failed"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
+          BROKEN=$(grep -l '"status": *"broken"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
+          SKIPPED=$(grep -l '"status": *"skipped"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
+          TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
+          echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          echo "broken=$BROKEN" >> $GITHUB_OUTPUT
+          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+          echo "Test counts: passed=$PASSED, failed=$FAILED, broken=$BROKEN, skipped=$SKIPPED, total=$TOTAL"
+
       # =========================================================================
       # PR: Deploy report to /pr/<number>/ on gh-pages (live hosted link)
       # =========================================================================
-
-      - name: Deploy PR report to GitHub Pages
-        if: github.event_name == 'pull_request'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./allure-report
-          destination_dir: pr/${{ github.event.pull_request.number }}
-          keep_files: true
 
       - name: Comment PR with live report link
         if: github.event_name == 'pull_request'
@@ -137,6 +143,8 @@ jobs:
               `## 📊 Allure Report`,
               ``,
               `🔗 **[View Report](${reportUrl})**`,
+              ``,
+              `Live report: ${reportUrl}`,
               ``,
               `| Suite | Status |`,
               `|-------|--------|`,
@@ -170,6 +178,74 @@ jobs:
               });
             }
 
+      - name: Build PR deploy with metadata
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          TEST_PASSED: ${{ steps.tests-lazytest.outcome == 'success' && steps.tests-ct.outcome == 'success' }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TESTS_PASSED: ${{ steps.test-counts.outputs.passed }}
+          TESTS_FAILED: ${{ steps.test-counts.outputs.failed }}
+          TESTS_BROKEN: ${{ steps.test-counts.outputs.broken }}
+          TESTS_SKIPPED: ${{ steps.test-counts.outputs.skipped }}
+          TESTS_TOTAL: ${{ steps.test-counts.outputs.total }}
+        run: |
+          mkdir -p /tmp/pr-deploy/pr/${PR_NUM}
+          cp -r allure-report/* /tmp/pr-deploy/pr/${PR_NUM}/
+
+          # Fetch current pr-builds.json from live site (fallback to empty array)
+          curl -sSf "${PAGES_BASE_URL}/pr-builds.json" -o /tmp/pr-builds-current.json 2>/dev/null || echo '[]' > /tmp/pr-builds-current.json
+
+          # Build new entry with jq (handles JSON escaping properly)
+          TIMESTAMP=$(date +%s)000
+          PASSED_BOOL=$([ "${TEST_PASSED}" = "true" ] && echo "true" || echo "false")
+
+          jq -n \
+            --arg run "pr/${PR_NUM}" \
+            --argjson pr_number "${PR_NUM}" \
+            --arg pr_title "${PR_TITLE}" \
+            --arg branch "${PR_BRANCH}" \
+            --arg sha "${PR_SHA}" \
+            --arg author "${PR_AUTHOR}" \
+            --argjson timestamp "${TIMESTAMP}" \
+            --argjson passed "${PASSED_BOOL}" \
+            --argjson tp "${TESTS_PASSED:-0}" \
+            --argjson tf "${TESTS_FAILED:-0}" \
+            --argjson tb "${TESTS_BROKEN:-0}" \
+            --argjson ts "${TESTS_SKIPPED:-0}" \
+            --argjson tt "${TESTS_TOTAL:-0}" \
+            --arg run_url "${RUN_URL}" \
+            --arg repo_url "${REPO_URL}" \
+            '{
+              run: $run, pr_number: $pr_number, pr_title: $pr_title,
+              branch: $branch, type: "pr", sha: $sha, message: $pr_title,
+              author: $author, timestamp: $timestamp, passed: $passed,
+              status: "completed",
+              tests: { passed: $tp, failed: $tf, broken: $tb, skipped: $ts, total: $tt },
+              run_url: $run_url, repo_url: $repo_url
+            }' > /tmp/pr-entry.json
+
+          # Remove old entry for same PR, prepend new, keep max 20
+          jq --slurpfile entry /tmp/pr-entry.json \
+             --argjson pr_num "${PR_NUM}" \
+             '[ $entry[0] ] + [ .[] | select(.pr_number != $pr_num) ] | .[0:20]' \
+             /tmp/pr-builds-current.json > /tmp/pr-deploy/pr-builds.json
+
+          echo "PR #${PR_NUM} deploy ready with $(jq length /tmp/pr-deploy/pr-builds.json) entries in pr-builds.json"
+
+      - name: Deploy PR report to GitHub Pages
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/pr-deploy
+          keep_files: true
+
       # =========================================================================
       # Main: Full site deploy with per-build reports
       # =========================================================================
@@ -194,20 +270,21 @@ jobs:
                  :run-number   (System/getenv \"RUN_NUMBER\")})"
           fi
 
-      - name: Extract test counts from Allure results
-        id: test-counts
+      - name: Preserve PR reports from gh-pages
+        if: github.ref == 'refs/heads/main'
         run: |
-          PASSED=$(grep -l '"status": *"passed"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
-          FAILED=$(grep -l '"status": *"failed"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
-          BROKEN=$(grep -l '"status": *"broken"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
-          SKIPPED=$(grep -l '"status": *"skipped"' allure-results/*-result.json 2>/dev/null | wc -l | tr -d ' ')
-          TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "broken=$BROKEN" >> $GITHUB_OUTPUT
-          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
-          echo "total=$TOTAL" >> $GITHUB_OUTPUT
-          echo "Test counts: passed=$PASSED, failed=$FAILED, broken=$BROKEN, skipped=$SKIPPED, total=$TOTAL"
+          git fetch origin gh-pages --depth=1 || true
+          mkdir -p gh-pages-site
+          if git ls-tree --name-only origin/gh-pages pr/ >/dev/null 2>&1; then
+            git checkout origin/gh-pages -- pr/
+            cp -r pr gh-pages-site/pr/
+            rm -rf pr
+            echo "Preserved $(ls -1d gh-pages-site/pr/*/ 2>/dev/null | wc -l) PR report(s)"
+          fi
+          if git show origin/gh-pages:pr-builds.json >/dev/null 2>&1; then
+            git show origin/gh-pages:pr-builds.json > gh-pages-site/pr-builds.json
+            echo "Preserved pr-builds.json"
+          fi
 
       - name: Assemble site with per-build reports
         if: github.ref == 'refs/heads/main'
@@ -313,19 +390,9 @@ jobs:
           path: gh-pages-site
           key: allure-site-${{ github.run_number }}
 
-      - name: Preserve PR reports from gh-pages
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git fetch origin gh-pages --depth=1 || true
-          if git show gh-pages:pr/ >/dev/null 2>&1; then
-            git checkout gh-pages -- pr/
-            cp -r pr gh-pages-site/pr/
-            echo "Preserved $(ls -1d gh-pages-site/pr/*/ 2>/dev/null | wc -l) PR report(s)"
-          fi
-
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages-site

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -17,17 +17,34 @@ jobs:
           ref: gh-pages
           fetch-depth: 1
 
-      - name: Remove PR report directory
+      - name: Remove PR report and metadata
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
+          CHANGED=false
           if [ -d "pr/${PR_NUM}" ]; then
             git rm -rf "pr/${PR_NUM}"
+            CHANGED=true
+            echo "Removed report for PR #${PR_NUM}"
+          else
+            echo "No report found for PR #${PR_NUM}"
+          fi
+
+          if [ -f "pr-builds.json" ]; then
+            jq --argjson pr_num "${PR_NUM}" \
+               '[ .[] | select(.pr_number != $pr_num) ]' \
+               pr-builds.json > pr-builds-updated.json
+            mv pr-builds-updated.json pr-builds.json
+            git add pr-builds.json
+            CHANGED=true
+            echo "Removed PR #${PR_NUM} from pr-builds.json"
+          fi
+
+          if [ "$CHANGED" = "true" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git commit -m "cleanup: remove PR #${PR_NUM} report"
             git push origin gh-pages
-            echo "Removed report for PR #${PR_NUM}"
           else
-            echo "No report found for PR #${PR_NUM}, skipping"
+            echo "Nothing to clean up for PR #${PR_NUM}"
           fi

--- a/resources/allure-index.html
+++ b/resources/allure-index.html
@@ -15,6 +15,7 @@
       --green-text: #1d7a22; --red: #d94040; --red-bg: rgba(217,64,64,0.05); --red-border: rgba(217,64,64,0.2);
       --red-text: #b33030; --code-bg: #eef0f4; --code-text: #5a6070;
       --yellow: #d4a017; --yellow-bg: rgba(255,193,7,0.06); --yellow-border: rgba(255,193,7,0.3);
+      --purple: #7c3aed; --purple-bg: rgba(124,58,237,0.06); --purple-border: rgba(124,58,237,0.2); --purple-text: #6d28d9;
       --shadow: 0 1px 2px rgba(0,0,0,0.04);
       --shadow-h: 0 3px 8px rgba(0,0,0,0.07), 0 1px 2px rgba(0,0,0,0.04);
     }
@@ -26,6 +27,7 @@
       --green-text: #4cd952; --red-bg: rgba(217,64,64,0.08); --red-border: rgba(217,64,64,0.25);
       --red-text: #f06060; --code-bg: #252d3d; --code-text: #9ba3b5;
       --yellow-bg: rgba(255,193,7,0.08); --yellow-border: rgba(255,193,7,0.35);
+      --purple-bg: rgba(124,58,237,0.08); --purple-border: rgba(124,58,237,0.25); --purple-text: #a78bfa;
       --shadow: 0 1px 2px rgba(0,0,0,0.2); --shadow-h: 0 4px 12px rgba(0,0,0,0.3);
     }
     body { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
@@ -63,6 +65,8 @@
       cursor: pointer;
     }
     .card:hover { border-color: var(--border-hover); border-left-color: var(--green); background: var(--bg-card-hover); box-shadow: var(--shadow-h); transform: translateY(-1px); }
+    .card.pr { border-left-color: var(--purple); }
+    .card.pr:hover { border-color: var(--purple-border); border-left-color: var(--purple); }
     .card.failed { border-left-color: var(--red); background: var(--red-bg); }
     .card.failed:hover { border-color: var(--red-border); border-left-color: var(--red); }
     .card.in-progress { border-left-color: var(--yellow); background: var(--yellow-bg); }
@@ -75,6 +79,7 @@
     .run-num { font-size: 1.05rem; font-weight: 700; font-variant-numeric: tabular-nums; color: var(--text); line-height: 1; }
     a.run-link { text-decoration: none; color: var(--text); transition: color 0.15s; }
     a.run-link:hover { color: var(--green); }
+    .card.pr a.run-link:hover { color: var(--purple); }
     .status-dot { flex-shrink: 0; font-size: 0.65rem; font-weight: 700; line-height: 1; }
     .status-pass { color: var(--green); }
     .status-fail { color: var(--red); }
@@ -104,8 +109,10 @@
     .pill-yellow { background: rgba(255,193,7,0.10); color: #8a6d00; border-color: rgba(255,193,7,0.4); }
     .pill-blue { background: rgba(0,126,198,0.08); color: #006bb3; border-color: rgba(0,126,198,0.3); }
     .pill-red { background: var(--red-bg); color: var(--red-text); border-color: var(--red-border); }
+    .pill-purple { background: var(--purple-bg); color: var(--purple-text); border-color: var(--purple-border); }
     html.dark .pill-yellow { background: rgba(255,193,7,0.12); color: #ffd54f; border-color: rgba(255,193,7,0.35); }
     html.dark .pill-blue { background: rgba(0,126,198,0.12); color: #64b5f6; border-color: rgba(0,126,198,0.35); }
+    html.dark .pill-purple { background: rgba(124,58,237,0.12); color: #c4b5fd; border-color: rgba(124,58,237,0.35); }
     .pill-in-progress { background: rgba(255,193,7,0.12); color: #8a6d00; border-color: rgba(255,193,7,0.4); animation: pulse 2s infinite; }
     html.dark .pill-in-progress { background: rgba(255,193,7,0.15); color: #ffd54f; border-color: rgba(255,193,7,0.4); }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
@@ -369,7 +376,8 @@
       var delay = Math.min(i, 9) * 0.04;
       var inProgress = b.status === 'in_progress';
       var failed = !inProgress && b.passed === false;
-      var cardClass = 'card' + (failed ? ' failed' : '') + (inProgress ? ' in-progress' : '');
+      var isPR = b.type === 'pr';
+      var cardClass = 'card' + (isPR ? ' pr' : '') + (failed ? ' failed' : '') + (inProgress ? ' in-progress' : '');
 
       var shaHtml = '';
       if (sha) {
@@ -408,20 +416,25 @@
         }
       }
 
+      var prBadge = isPR ? '<span class="pill pill-purple">PR #' + b.pr_number + '</span>' : '';
+      var runLabel = isPR ? '#' + b.pr_number : '#' + b.run;
+      var authorLine = author ? '<p class="author">by ' + author + (isPR && b.branch ? ' \u00b7 ' + b.branch : '') + '</p>' : '';
+
       var clickHandler = inProgress ? '' : 'onclick="window.location.href=\'' + b.run + '/\'"';
       return '<div class="' + cardClass + '" style="animation-delay:' + delay + 's" ' + clickHandler + ' role="link" tabindex="0">'
         + '<div class="run">'
         + (runUrl
-          ? '<a href="' + runUrl + '" class="run-num run-link" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View CI pipeline">#' + b.run + '</a>'
-          : '<div class="run-num">#' + b.run + '</div>')
+          ? '<a href="' + runUrl + '" class="run-num run-link" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View CI pipeline">' + runLabel + '</a>'
+          : '<div class="run-num">' + runLabel + '</div>')
         + statusDot
         + '</div>'
         + '<div class="info"><div class="info-top">'
+        + prBadge
         + shaHtml
         + testBadge
         + versionBadge
         + '</div><p class="msg">' + (msg || 'No commit message') + '</p>'
-        + (author ? '<p class="author">by ' + author + '</p>' : '')
+        + authorLine
         + '</div>'
         + '<div class="meta">'
         + (date ? '<div class="meta-date">' + date + '</div>' : '')
@@ -441,26 +454,29 @@
       return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
     }
 
-    fetch('builds.json')
-      .then(function(r) { return r.json(); })
-      .then(function(builds) {
-        var el = document.getElementById('builds');
-        if (!builds.length) { document.getElementById('empty').classList.add('show'); return; }
-        var html = '';
-        var lastGroup = '';
-        builds.forEach(function(b, i) {
-          if (b.timestamp) {
-            var group = dateLabel(b.timestamp);
-            if (group !== lastGroup) {
-              html += '<div class="date-group">' + group + '</div>';
-              lastGroup = group;
-            }
+    Promise.all([
+      fetch('builds.json').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
+      fetch('pr-builds.json').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; })
+    ]).then(function(results) {
+      var builds = results[0].concat(results[1]).sort(function(a, b) {
+        return (b.timestamp || 0) - (a.timestamp || 0);
+      });
+      var el = document.getElementById('builds');
+      if (!builds.length) { document.getElementById('empty').classList.add('show'); return; }
+      var html = '';
+      var lastGroup = '';
+      builds.forEach(function(b, i) {
+        if (b.timestamp) {
+          var group = dateLabel(b.timestamp);
+          if (group !== lastGroup) {
+            html += '<div class="date-group">' + group + '</div>';
+            lastGroup = group;
           }
-          html += renderBuild(b, i);
-        });
-        el.innerHTML = html;
-      })
-      .catch(function() { document.getElementById('empty').classList.add('show'); });
+        }
+        html += renderBuild(b, i);
+      });
+      el.innerHTML = html;
+    }).catch(function() { document.getElementById('empty').classList.add('show'); });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- PR Allure reports are now deployed live to GitHub Pages at `/pr/<number>/` (via peaceiris)
- PR metadata stored in `pr-builds.json` on gh-pages (jq-based, capped at 20 entries)
- Landing page fetches both `builds.json` and `pr-builds.json`, merges them into a unified sorted-by-timestamp list
- PR cards get a purple `PR #N` pill badge with branch name shown in author line
- Main deploy preserves existing PR reports by fetching from `origin/gh-pages` before deploying
- `pr-cleanup.yml` updated to also remove PR entry from `pr-builds.json`
- Switched main deploy from `actions/deploy-pages@v4` to `peaceiris/actions-gh-pages@v4` (consistent with branch-based Pages config)

## Changes

| File | What |
|------|------|
| `.github/workflows/allure.yml` | PR deploy steps, preserve PR reports in main deploy, test-counts moved earlier, peaceiris v4 |
| `.github/workflows/pr-cleanup.yml` | Also removes PR entry from `pr-builds.json` via jq |
| `resources/allure-index.html` | Purple PR card styling, `Promise.all` fetch for both builds + PR builds, PR badge + branch display |

## Testing

This PR will itself trigger the Allure workflow and deploy its report to `/pr/<N>/`. Once deployed:
1. Check `https://blockether.github.io/spel/pr/<N>/` for the live PR report
2. Check `https://blockether.github.io/spel/pr-builds.json` for PR metadata
3. Check the landing page at `https://blockether.github.io/spel/` for the PR entry in the builds list