### PR TITLE
fix: guard pr/ checkout with grep to avoid false-positive ls-tree exit code

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1 || true
           mkdir -p gh-pages-site
-          if git ls-tree --name-only origin/gh-pages pr/ >/dev/null 2>&1; then
+          if git ls-tree --name-only origin/gh-pages pr/ 2>/dev/null | grep -q .; then
             git checkout origin/gh-pages -- pr/
             cp -r pr gh-pages-site/pr/
             rm -rf pr


### PR DESCRIPTION
## Summary
- Fix CI failure in 'Preserve PR reports from gh-pages' step
- `git ls-tree` always exits 0 even when path doesn't exist — the `if` condition was always true
- Changed to pipe through `grep -q .` to verify actual output exists before attempting checkout

**Failed run:** https://github.com/Blockether/spel/actions/runs/22338634420/job/64637155190