### PR TITLE
fix: coerce max-n to long for GraalVM primitive math

### DIFF
--- a/src/com/blockether/spel/ci.clj
+++ b/src/com/blockether/spel/ci.clj
@@ -333,7 +333,7 @@
                    [])
         pr-num   (parse-num pr-number)
         run-num  (parse-num run-number)
-        max-n    (or (parse-num max-pr-builds) default-max-pr-builds)
+        max-n    (long (or (parse-num max-pr-builds) default-max-pr-builds))
         ts       (.toEpochMilli (Instant/now))
         msg-first (when pr-title (first (str/split-lines pr-title)))
         entry    {"run"        (str "pr/" pr-num)


### PR DESCRIPTION
Fixes boxed math warning in ci.clj:364 that was breaking CI on main.

The `dec` call on `max-n` caused boxed math because the `or` form produces Object type at compile time.
Adding explicit `long` coercion ensures primitive arithmetic for GraalVM native-image.