### PR TITLE
perf: native-image optimization flags (elide-meta + dynaload AOT)

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -70,9 +70,11 @@
   (clean nil)
   (b/copy-dir {:src-dirs ["src" "resources"]
                :target-dir class-dir})
-  (b/compile-clj {:basis     @native-basis
-                  :src-dirs  ["src"]
-                  :class-dir class-dir
+  (b/compile-clj {:basis      @native-basis
+                  :src-dirs   ["src"]
+                  :class-dir  class-dir
+                  :jvm-opts   ["-Dborkdude.dynaload.aot=true"
+                               "-Dclojure.compiler.elide-meta=[:doc :file :line :column]"]
                   :ns-compile ['com.blockether.spel.native]})
   (b/uber {:class-dir class-dir
            :uber-file uber-file
@@ -107,6 +109,9 @@
                      "native-image.cmd"
                      "native-image")
         cmd        (cond-> [ni-cmd
+                            ;; Pass dynaload AOT flag to the JVM running native-image
+                            ;; so it can see the pre-compiled dynaload initializers.
+                            "-J-Dborkdude.dynaload.aot=true"
                             "-jar" uber-file
                             "-o" native-binary]
                      (seq extra-args)

--- a/deps.edn
+++ b/deps.edn
@@ -31,5 +31,14 @@
              :jvm-opts    ["-Dallure.clojure-test.enabled=true"]
              :main-opts   ["-e" "(require 'com.blockether.spel.ct.smoke-test 'com.blockether.spel.ct.markdown-test 'com.blockether.spel.ct.data-test 'com.blockether.spel.ct.testing-page-test) (let [{:keys [fail error]} (clojure.test/run-tests 'com.blockether.spel.ct.smoke-test 'com.blockether.spel.ct.markdown-test 'com.blockether.spel.ct.data-test 'com.blockether.spel.ct.testing-page-test)] (when (pos? (+ fail error)) (System/exit 1)))"]}
 
-  :native {:extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}
-           :jvm-opts   ["-Dclojure.compiler.direct-linking=true"]}}}
+  :native {:extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}
+                        borkdude/dynaload                   {:mvn/version "0.3.5"}}
+           :jvm-opts   ["-Dclojure.compiler.direct-linking=true"
+                        ;; AOT-compile all dynaloaded vars at build time instead
+                        ;; of using runtime require - reduces binary size.
+                        ;; See: https://github.com/borkdude/dynaload#graalvm
+                        "-Dborkdude.dynaload.aot=true"
+                        ;; Elide metadata not needed at runtime.
+                        ;; :doc :file :line :column are only used for dev tooling;
+                        ;; spel's public API docs live in EDN resources, not inline.
+                        "-Dclojure.compiler.elide-meta=[:doc :file :line :column]"]}}}


### PR DESCRIPTION
## What

Two build-time JVM flags that reduce native binary size:

### 1. `-Dclojure.compiler.elide-meta=[:doc :file :line :column]`

Strips docstrings and source location metadata from AOT-compiled classes. Safe for spel because the public API docs live in EDN resources (`resources/com/blockether/spel/`), not inline — so `gen-docs` is unaffected.

### 2. `-Dborkdude.dynaload.aot=true`

Tells the [dynaload](https://github.com/borkdude/dynaload) library to resolve all dynaloaded vars at compile time instead of using runtime `require`. Applied to both the AOT compile step and the native-image JVM (`-J-Dborkdude.dynaload.aot=true`).

## Before (v0.3.1)

| Platform | Size |
|---|---|
| linux-amd64 | 58.8 MB |
| linux-arm64 | 59.5 MB |
| macos-arm64 | 52.0 MB |
| windows-amd64 | 52.5 MB |

## After

See CI artifacts on this PR — native-image workflow does not run on PRs (only on main/tags), trigger manually or merge to see results.

## Changes

- `deps.edn` — added `borkdude/dynaload 0.3.5` to `:native` extra-deps, added two JVM opts
- `build.clj` — added `:jvm-opts` to `compile-clj` call, added `-J-Dborkdude.dynaload.aot=true` to native-image command