### PR TITLE
fix: escape quotes in Allure workflow Clojure code

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -225,8 +225,8 @@ jobs:
                                 :broken  (parse-long (or (System/getenv \"TESTS_BROKEN\") \"0\"))
                                 :skipped (parse-long (or (System/getenv \"TESTS_SKIPPED\") \"0\"))
                                 :total   (parse-long (or (System/getenv \"TESTS_TOTAL\") \"0\"))}
-               :max-pr-builds  (parse-long (or (System/getenv "MAX_PR_REPORTS") "50"))
-               :pr-url         (System/getenv "PR_URL")})"
+               :max-pr-builds  (parse-long (or (System/getenv \"MAX_PR_REPORTS\") \"50\"))
+               :pr-url         (System/getenv \"PR_URL\")})"
 
 
       - name: Deploy PR report to GitHub Pages


### PR DESCRIPTION
Fixes a Clojure REPL error in the Allure workflow where unescaped quotes caused 'Unable to resolve symbol: PR_URL in this context'.

The YAML multiline string uses double quotes, so internal double quotes must be escaped as `\"`.