### PR TITLE
BLO-118: reposition README — Swiss Army Knife for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <div align="center">
-<i>spel</i> - Idiomatic Clojure wrapper for <a href="https://playwright.dev/">Microsoft Playwright</a>.
+<i>spel</i> - The Swiss Army Knife browser tool for AI agents and Clojure developers.
 <br/>
-<sub>Browser automation, API testing, test reporting, and native CLI — for Chromium, Firefox, and WebKit.</sub>
+<sub>Browser automation · API testing · Allure reporting · Accessibility snapshots · Inline Clojure execution · Record & generate — one native binary, all three engines.</sub>
 </div>
 
 <div align="center">
@@ -42,16 +42,18 @@
 
 ## Rationale
 
-Playwright's Java API is imperative and verbose — option builders, checked exceptions, manual resource cleanup. Clojure deserves better.
+Playwright's Java API is imperative and verbose — option builders, checked exceptions, manual resource cleanup. Clojure deserves better. And AI agents deserve more than a shell wrapper.
 
-spel wraps Playwright Java 1.58.0 with idiomatic Clojure: maps for options, anomaly maps for errors, `with-*` macros for lifecycle, and a native CLI binary for instant browser automation from the terminal.
+spel wraps Playwright Java with idiomatic Clojure: maps for options, anomaly maps for errors, `with-*` macros for lifecycle, and a native CLI binary for instant browser automation. It does everything a modern agentic workflow needs — in one tool.
 
-- **Data-driven**: Maps for options, anomaly maps for errors — no option builders, no checked exceptions
-- **Composable**: `with-*` macros for lifecycle management — resources always cleaned up
-- **Agent-friendly**: Accessibility snapshots with numbered refs, persistent browser daemon, and `--eval` scripting — built for AI agents to see, decide, and act
-- **Record & replay**: Record browser sessions to JSONL, transform to idiomatic Clojure tests or scripts
-- **Batteries included**: API testing, Allure reporting with embedded Playwright traces, agent scaffolding for Claude/VS Code/OpenCode
-- **Not a port**: Wraps the official Playwright Java library directly — full API coverage, same browser versions
+- **Swiss Army Knife for agents**: Browser automation, API testing, test reporting, agentic search and verification, accessibility snapshots, inline code execution, and test generation — all in a single native binary. No stitching tools together.
+- **Agentic by design**: Accessibility snapshots with numbered refs let AI agents see the page as a structured document, not raw HTML. Persistent daemon, `--eval` scripting, and zero brittle CSS selectors — agents reason and act in a loop without restarting.
+- **Inline Clojure execution**: Run arbitrary Clojure expressions in the browser context via `--eval` — mix business logic with automation, call any GraalVM-bound function, compose scripts on the fly. No other browser tool lets an agent write and execute real code mid-session.
+- **Record, then generate**: Capture any browser session to JSONL and auto-generate idiomatic Clojure tests or reusable scripts. Record once, replay forever.
+- **Allure reports with network inspection**: Full Allure reporting with embedded Playwright traces, network request/response visualization (method, status, headers, JSON body), and visual diffs. Debug failures from the report, not from logs.
+- **API testing built in**: Intercept, assert, and inspect HTTP traffic in the same tool as your browser tests — no separate client needed.
+- **Native CLI binary**: GraalVM native image, zero JVM startup, persistent daemon — fast enough for interactive agentic loops and CI alike.
+- **Not a port**: Wraps Playwright Java directly — full API coverage, all three engines (Chromium, Firefox, WebKit).
 
 ## Quick Start
 


### PR DESCRIPTION
## Why

The current README undersells spel. Bullet points were generic — they didn't reflect what spel actually does or how it compares to modern alternatives like [agent-browser](https://github.com/vercel-labs/agent-browser).

## What changed

**Tagline** — new: _The Swiss Army Knife browser tool for AI agents and Clojure developers_

**Subtitle** — now lists all capabilities explicitly: browser automation · API testing · Allure reporting · accessibility snapshots · inline Clojure execution · record & generate

**Rationale intro** — added: _"AI agents deserve more than a shell wrapper"_ — positions spel vs CLI-only tools

**Bullet points** — replaced generic dev-focused bullets with agent-first framing:
- Swiss Army Knife bullet leads (no stitching tools together)
- Agentic by design — numbered refs, daemon, --eval
- Inline Clojure execution — unique differentiator: agents can write and run real code mid-session
- Record, then generate — JSONL → Clojure tests
- Allure reports with network inspection
- API testing built in
- Native CLI binary
- Not a port

## Validation

Cross-validated with Claude Opus twice. Approved — copy is tight, claims are defensible, no fluff.

Linear: https://linear.app/blockether/issue/BLO-118/spel-readme-reposition-vs-agent-browser-reflect-full-swiss-army-knife