### PR TITLE
Switch spel daemon to virtual threads

### DIFF
--- a/src/com/blockether/spel/daemon.clj
+++ b/src/com/blockether/spel/daemon.clj
@@ -32,7 +32,8 @@
    [java.net StandardProtocolFamily UnixDomainSocketAddress]
    [java.nio.channels Channels ServerSocketChannel SocketChannel]
    [java.nio.file Files Path]
-   [java.util Base64]))
+   [java.util Base64]
+   [java.util.concurrent ExecutorService Executors]))
 
 (declare stop-daemon!)
 (declare save-inflight-trace!)
@@ -88,6 +89,13 @@
          :tracing? false}))
 
 (defonce ^:private !server (atom nil))
+(defonce ^:private ^ExecutorService !vthread-executor
+  (Executors/newVirtualThreadPerTaskExecutor))
+
+(defn- submit-virtual
+  "Submits a task to the virtual thread executor."
+  [^Runnable f]
+  (.submit !vthread-executor f))
 (defonce ^:private !console-messages (atom []))
 (defonce ^:private !page-errors (atom []))
 (defonce ^:private !dialog-handler (atom nil))
@@ -1452,7 +1460,7 @@
                               (let [parsed (try (json/read-json response) (catch Exception _ nil))]
                                 (and parsed (get-in parsed ["data" "shutdown"])))))]
             (if shutdown?
-              (future (stop-daemon!))
+              (submit-virtual stop-daemon!)
               (recur)))))
       (catch Exception e (warn "handle-connection" e))
       (finally
@@ -1573,7 +1581,7 @@
       (try
         (loop []
           (let [client (.accept server)]
-            (future (handle-connection client)))
+            (submit-virtual #(handle-connection client)))
           (recur))
         (catch Exception _
           ;; Server closed


### PR DESCRIPTION
BLO-132

Replace future-based thread pool with Java 21+ virtual threads in spel daemon.

The daemon uses Unix domain sockets (not Jetty), so the change replaces `future` calls with a `newVirtualThreadPerTaskExecutor`. Each client connection and shutdown task now runs on a virtual thread.

**Changes:**
- Import `java.util.concurrent.{ExecutorService, Executors}`
- Create a shared virtual thread executor via `Executors/newVirtualThreadPerTaskExecutor`
- Replace `(future (handle-connection client))` and `(future (stop-daemon!))` with virtual thread submissions

**Benefits:**
- Better scalability under concurrent connections
- No thread pool sizing needed
- Near-zero overhead per idle connection

**Testing:**
- Namespace compiles cleanly
- Requires Java 21+ (we run Java 25)