### PR TITLE
fix(templates): migrate all templates from old fixtures to with-testing-page/with-testing-api

### DIFF
--- a/resources/com/blockether/spel/templates/agents/spel-test-generator-ct.md
+++ b/resources/com/blockether/spel/templates/agents/spel-test-generator-ct.md
@@ -52,71 +52,45 @@ com.blockether.spel and `clojure.test` (`deftest`, `testing`, `is`).
 
 ## Code Pattern
 
-ALWAYS use `use-fixtures` to share browser lifecycle across tests. NEVER create `with-playwright`/`with-browser`/`with-traced-page` inside each `deftest` block.
-
-The project provides shared fixtures in `com.blockether.spel.test-fixtures`:
-- `with-playwright` — fixture that binds `*pw*`
-- `with-browser` — fixture that binds `*browser*` (headless Chromium)
-- `with-traced-page` — **default** fixture that binds `*page*` (fresh page per test, always enables tracing/HAR)
-- `with-page` — like `with-traced-page` but tracing only when Allure is active (use only if you explicitly want no tracing)
+ALWAYS use `core/with-testing-page` inside each `deftest` block. This macro handles the full Playwright stack automatically (playwright → browser → context → page). When Allure is active, tracing and HAR are enabled automatically.
 
 ```clojure
 (ns my-app.e2e.feature-test
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.test :refer [deftest testing is]]
    [com.blockether.spel.assertions :as assert]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.locator :as locator]
    [com.blockether.spel.page :as page]
-   [com.blockether.spel.roles :as role]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]))
-
-;; Playwright + browser shared across all tests in this namespace
-(use-fixtures :once with-playwright with-browser)
-
-;; Fresh page (with tracing/HAR) for each test
-(use-fixtures :each with-traced-page)
+   [com.blockether.spel.roles :as role]))
 
 (deftest feature-test
   (testing "does specific thing"
-    ;; 1. Navigate to the page
-    (page/navigate *page* "http://localhost:8080")
+    (core/with-testing-page [page]
+      ;; 1. Navigate to the page
+      (page/navigate page "http://localhost:8080")
 
-    ;; 2. Click the submit button
-    (locator/click (page/get-by-role *page* role/button))
+      ;; 2. Click the submit button
+      (locator/click (page/get-by-role page role/button))
 
-    ;; 3. Assert expected text
-    (is (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Welcome")))))
+      ;; 3. Assert expected text
+      (is (nil? (assert/has-text (assert/assert-that (page/locator page "h1")) "Welcome"))))))
 ```
 
-### How `use-fixtures` works
-
-| Fixture | Binds | Scope |
-|---------|-------|-------|
-| `with-playwright` | `*pw*` | `:once` — shared across all tests in the namespace |
-| `with-browser` | `*browser*` | `:once` — shared across all tests in the namespace |
-| `with-traced-page` | `*page*` | `:each` — fresh page for **each** `deftest` (auto-cleanup, tracing/HAR always enabled) |
-
-The `with-traced-page` hook creates a new BrowserContext + Page before each `deftest` and closes them after. This means each test gets isolation without paying the cost of launching a new browser. Tracing and HAR capture are always enabled so traces are available for debugging.
-
-Use a helper function to set up page state (e.g. navigate) shared by multiple tests:
+For options (device, viewport, locale, auth state):
 
 ```clojure
-(defn- navigate-to-dashboard []
-  (page/navigate *page* "http://localhost:8080/dashboard"))
-
-(deftest shows-welcome-heading
-  (navigate-to-dashboard)
-  (is (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Welcome"))))
-
-(deftest has-sidebar-navigation
-  (navigate-to-dashboard)
-  (is (locator/is-visible? (page/locator *page* "nav.sidebar"))))
+(deftest mobile-layout-test
+  (testing "renders correctly on mobile"
+    (core/with-testing-page {:device :iphone-14} [page]
+      (page/navigate page "http://localhost:8080")
+      (is (locator/is-visible? (page/locator page "nav.mobile"))))))
 ```
 
 ## Critical Rules
 
-- **Fixtures via `use-fixtures`**: ALWAYS use `(use-fixtures :once with-playwright with-browser)` and `(use-fixtures :each with-traced-page)` at namespace level. NEVER nest `with-playwright`/`with-browser`/`with-traced-page` manually inside `deftest` blocks.
-- **`*page*` dynamic var**: All test code uses `*page*` to access the current page. NEVER create pages manually in tests.
+- **`with-testing-page`**: ALWAYS use `(core/with-testing-page [page] ...)` inside `deftest` blocks. This handles the full stack automatically.
+- **Page binding**: The `[page]` binding in `with-testing-page` gives you the page. Use that symbol directly.
 - **`assert-that` first**: ALWAYS wrap locator/page with `(assert/assert-that ...)` before passing to assertion functions.
 - **`(is (nil? ...))` for assertions**: Playwright assertions return `nil` on success. ALWAYS wrap in `(is (nil? (assert/has-text ...)))` inside `deftest` blocks.
 - **Exact string assertions**: ALWAYS use exact text matching with `assert/has-text`. NEVER use substring.
@@ -146,15 +120,16 @@ Generate:
 ```clojure
 (deftest navigate-to-homepage-test
   (testing "navigates to homepage and clicks Get Started"
-    ;; 1. Navigate to http://localhost:8080
-    (page/navigate *page* "http://localhost:8080")
+    (core/with-testing-page [page]
+      ;; 1. Navigate to http://localhost:8080
+      (page/navigate page "http://localhost:8080")
 
-    ;; 2. Verify page title is "My App"
-    (is (nil? (assert/has-title (assert/assert-that *page*) "My App")))
+      ;; 2. Verify page title is "My App"
+      (is (nil? (assert/has-title (assert/assert-that page) "My App")))
 
-    ;; 3. Click "Get Started" link
-    (locator/click (page/get-by-text *page* "Get Started"))
+      ;; 3. Click "Get Started" link
+      (locator/click (page/get-by-text page "Get Started"))
 
-    ;; Expected: URL changes to "/onboarding"
-    (is (nil? (assert/has-url (assert/assert-that *page*) #".*\/onboarding")))))
+      ;; Expected: URL changes to "/onboarding"
+      (is (nil? (assert/has-url (assert/assert-that page) #".*\/onboarding"))))))
 ```

--- a/resources/com/blockether/spel/templates/agents/spel-test-generator.md
+++ b/resources/com/blockether/spel/templates/agents/spel-test-generator.md
@@ -52,69 +52,50 @@ com.blockether.spel and `spel.allure` (`defdescribe`, `it`, `expect`).
 
 ## Code Pattern
 
-ALWAYS use `:context` fixtures to share browser lifecycle across tests. NEVER create `with-playwright`/`with-browser`/`with-traced-page` inside each `it` block.
+ALWAYS use `core/with-testing-page` inside each `it` block. This macro handles the full Playwright stack automatically.
 
-The project provides shared fixtures in `com.blockether.spel.test-fixtures`:
-- `with-playwright` — `around` hook that binds `*pw*`
-- `with-browser` — `around` hook that binds `*browser*` (headless Chromium)
-- `with-traced-page` — **default** `around` hook that binds `*page*` (fresh page per test, always enables tracing/HAR)
-- `with-page` — like `with-traced-page` but tracing only when Allure is active (use only if you explicitly want no tracing)
+`core/with-testing-page` is the all-in-one macro. It creates playwright → browser → context → page, runs your test body, and tears everything down. When Allure is active, tracing and HAR are enabled automatically.
 
 ```clojure
 (ns my-app.e2e.feature-test
   (:require
    [com.blockether.spel.assertions :as assert]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.locator :as locator]
    [com.blockether.spel.page :as page]
    [com.blockether.spel.roles :as role]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]
    [com.blockether.spel.allure :refer [defdescribe describe expect it]]))
 
 (defdescribe feature-test
   (describe "Scenario Group"
-    {:context [with-playwright with-browser with-traced-page]}
 
     (it "does specific thing"
-      ;; 1. Navigate to the page
-      (page/navigate *page* "http://localhost:8080")
+      (core/with-testing-page [page]
+        ;; 1. Navigate to the page
+        (page/navigate page "http://localhost:8080")
 
-      ;; 2. Click the submit button
-      (locator/click (page/get-by-role *page* role/button))
+        ;; 2. Click the submit button
+        (locator/click (page/get-by-role page role/button))
 
-      ;; 3. Assert expected text
-      (expect (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Welcome"))))))
+        ;; 3. Assert expected text
+        (expect (nil? (assert/has-text (assert/assert-that (page/locator page "h1")) "Welcome")))))))
 ```
 
-### How `:context` works
 
-| Fixture | Binds | Scope |
-|---------|-------|-------|
-| `with-playwright` | `*pw*` | Shared across all `it` blocks in the `describe` |
-| `with-browser` | `*browser*` | Shared across all `it` blocks in the `describe` |
-| `with-traced-page` | `*page*` | **Default.** Fresh page for **each** `it` block (auto-cleanup, tracing/HAR always enabled) |
-
-The `with-traced-page` hook creates a new BrowserContext + Page before each `it` and closes them after. This means each test gets isolation without paying the cost of launching a new browser. Tracing and HAR capture are always enabled so traces are available for debugging.
-
-Use `before-each` to set up page state (e.g. navigate) shared by multiple `it` blocks in the same `describe`:
+For options (device, viewport, locale, auth state):
 
 ```clojure
-(describe "after navigating to dashboard"
-  {:context [with-playwright with-browser with-traced-page]}
-
-  (before-each
-    (page/navigate *page* "http://localhost:8080/dashboard"))
-
-  (it "shows welcome heading"
-    (expect (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Welcome"))))
-
-  (it "has sidebar navigation"
-    (expect (locator/is-visible? (page/locator *page* "nav.sidebar")))))
+(it "renders mobile layout"
+  (core/with-testing-page {:device :iphone-14} [page]
+    (page/navigate page "http://localhost:8080")
+    (expect (locator/is-visible? (page/locator page "nav.mobile")))))
 ```
+
 
 ## Critical Rules
 
-- **Fixtures via `:context`**: ALWAYS use `{:context [with-playwright with-browser with-traced-page]}` on `describe`. NEVER nest `with-playwright`/`with-browser`/`with-traced-page` manually inside `it` blocks.
-- **`*page*` dynamic var**: All test code uses `*page*` to access the current page. NEVER create pages manually in tests.
+- **`with-testing-page`**: ALWAYS use `(core/with-testing-page [page] ...)` inside `it` blocks. This handles the full stack automatically.
+- **Page binding**: The `[page]` binding in `with-testing-page` gives you the page. Use that symbol directly.
 - **`assert-that` first**: ALWAYS wrap locator/page with `(assert/assert-that ...)` before passing to assertion functions.
 - **`(expect (nil? ...))` for assertions**: Playwright assertions return `nil` on success. ALWAYS wrap in `(expect (nil? (assert/has-text ...)))` inside `it` blocks.
 - **Exact string assertions**: ALWAYS use exact text matching with `assert/has-text`. NEVER use substring.
@@ -143,18 +124,18 @@ For a test plan:
 Generate:
 ```clojure
 (describe "homepage navigation"
-  {:context [with-playwright with-browser with-traced-page]}
 
   (it "navigates to homepage and clicks Get Started"
-    ;; 1. Navigate to http://localhost:8080
-    (page/navigate *page* "http://localhost:8080")
+    (core/with-testing-page [page]
+      ;; 1. Navigate to http://localhost:8080
+      (page/navigate page "http://localhost:8080")
 
-    ;; 2. Verify page title is "My App"
-    (expect (nil? (assert/has-title (assert/assert-that *page*) "My App")))
+      ;; 2. Verify page title is "My App"
+      (expect (nil? (assert/has-title (assert/assert-that page) "My App")))
 
-    ;; 3. Click "Get Started" link
-    (locator/click (page/get-by-text *page* "Get Started"))
+      ;; 3. Click "Get Started" link
+      (locator/click (page/get-by-text page "Get Started"))
 
-    ;; Expected: URL changes to "/onboarding"
-    (expect (nil? (assert/has-url (assert/assert-that *page*) #".*\/onboarding")))))
+      ;; Expected: URL changes to "/onboarding"
+      (expect (nil? (assert/has-url (assert/assert-that page) #".*\/onboarding"))))))
 ```

--- a/resources/com/blockether/spel/templates/flavours/clojure-test/testing-conventions.md
+++ b/resources/com/blockether/spel/templates/flavours/clojure-test/testing-conventions.md
@@ -1,7 +1,8 @@
 ## Testing Conventions
 
 - Framework: **`clojure.test`** (`deftest`, `testing`, `is`, `use-fixtures`)
-- Fixtures: `use-fixtures` with shared hooks from `com.blockether.spel.test-fixtures`
+- Page setup: **`core/with-testing-page`** — all-in-one macro (playwright + browser + context + page)
+- API testing: **`core/with-testing-api`** — all-in-one macro for API request contexts
 - Assertions: **Exact string matching** (NEVER substring unless explicitly `contains-text`)
 - Require: `[com.blockether.spel.roles :as role]` for role-based locators (e.g. `role/button`, `role/heading`). All roles are also available in `--eval` mode via the `role/` namespace — see the Enums table in SCI Eval API Reference below
 - Integration tests: Live against `example.com`
@@ -19,61 +20,50 @@ clojure -M:test -n {{ns}}.e2e.seed-test
 clojure -M:test --output nested --output com.blockether.spel.allure-reporter/allure
 ```
 
-### Test Fixtures
+### with-testing-page
 
-The project provides shared fixture functions in `com.blockether.spel.test-fixtures`:
-
-| Fixture | Binds | Scope |
-|---------|-------|-------|
-| `with-playwright` | `*pw*` | Shared Playwright instance |
-| `with-browser` | `*browser*` | Shared headless Chromium browser |
-| `with-traced-page` | `*page*` | **Default.** Fresh page per `deftest` with tracing/HAR always enabled (auto-cleanup) |
-| `with-page` | `*page*` | Fresh page per `deftest` (auto-cleanup, tracing only when Allure is active) |
-| `with-traced-page-opts` | `*page*` | Like `with-traced-page` but accepts context-opts map (use `:around` key) |
-| `with-page-opts` | `*page*` | Like `with-page` but accepts context-opts map (use `:around` key) |
-| `with-test-server` | `*test-server-url*` | Local HTTP test server |
-
-**Always use `with-traced-page` as the default** — it enables Playwright tracing and HAR capture on every test run, so traces are always available for debugging. Use `with-page` only if you explicitly want tracing disabled outside Allure.
-
-Use `(use-fixtures :once with-playwright with-browser)` and `(use-fixtures :each with-traced-page)` at namespace level. NEVER nest `with-playwright`/`with-browser`/`with-traced-page` manually inside `deftest` blocks.
-
-#### Custom Context Options
-
-To pass `Browser$NewContextOptions` (viewport, locale, color-scheme, storage-state, user-agent, etc.) use `with-page-opts` or `with-traced-page-opts`:
+All-in-one macro that creates the full Playwright stack (playwright → browser → context → page), binds the page, runs body, and tears everything down automatically. When Allure is active, tracing and HAR are enabled automatically.
 
 ```clojure
-;; Mobile viewport with French locale — extract :around from opts map
-(use-fixtures :each (:around (with-traced-page-opts {:viewport {:width 375 :height 812}
-                                                      :locale "fr-FR"})))
+;; Basic usage
+(core/with-testing-page [page]
+  (page/navigate page "https://example.com")
+  (is (= "Example Domain" (page/title page))))
 
-(deftest renders-mobile-layout
-  (page/navigate *page* "https://example.com")
-  (is (= "fr-FR" (page/evaluate *page* "navigator.language"))))
+;; With options (device, viewport, locale, etc.)
+(core/with-testing-page {:device :iphone-14} [page]
+  (page/navigate page "https://example.com"))
+
+;; Load saved auth state
+(core/with-testing-page {:storage-state "auth.json"} [page]
+  (page/navigate page "https://app.example.com/dashboard"))
 ```
 
-All `*browser-context*` and `*browser-api*` bindings work the same as with the default fixtures.
+### with-testing-api
+
+All-in-one macro for API testing. Creates playwright → browser → context → API request context with automatic tracing.
+
+```clojure
+(core/with-testing-api {:base-url "https://api.example.com"} [ctx]
+  (api/get ctx "/users"))
+```
 
 ### Test Example
 
 ```clojure
 (ns my-app.e2e.seed-test
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.test :refer [deftest testing is]]
    [com.blockether.spel.assertions :as assert]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.locator :as locator]
    [com.blockether.spel.page :as page]
-   [com.blockether.spel.roles :as role]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]))
-
-;; Playwright + browser shared across all tests in this namespace
-(use-fixtures :once with-playwright with-browser)
-
-;; Fresh page (with tracing/HAR) for each test
-(use-fixtures :each with-traced-page)
+   [com.blockether.spel.roles :as role]))
 
 (deftest homepage-test
   (testing "loads successfully"
-    (page/navigate *page* "https://example.com")
-    (is (= "Example Domain" (page/title *page*)))
-    (is (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Example Domain")))))
+    (core/with-testing-page [page]
+      (page/navigate page "https://example.com")
+      (is (= "Example Domain" (page/title page)))
+      (is (nil? (assert/has-text (assert/assert-that (page/locator page "h1")) "Example Domain"))))))
 ```

--- a/resources/com/blockether/spel/templates/flavours/lazytest/testing-conventions.md
+++ b/resources/com/blockether/spel/templates/flavours/lazytest/testing-conventions.md
@@ -1,7 +1,8 @@
 ## Testing Conventions
 
 - Framework: **`spel.allure`** (`defdescribe`, `describe`, `it`, `expect`) — NOT `lazytest.core`
-- Fixtures: `:context` with shared `around` hooks from `com.blockether.spel.test-fixtures`
+- Page setup: **`core/with-testing-page`** — all-in-one macro (playwright + browser + context + page)
+- API testing: **`core/with-testing-api`** — all-in-one macro for API request contexts
 - Assertions: **Exact string matching** (NEVER substring unless explicitly `contains-text`)
 - Require: `[com.blockether.spel.roles :as role]` for role-based locators (e.g. `role/button`, `role/heading`). All roles are also available in `--eval` mode via the `role/` namespace — see the Enums table in SCI Eval API Reference below
 - Integration tests: Live against `example.com`
@@ -41,48 +42,42 @@ clojure -M:test -d test/com/blockether/spel
 
 **IMPORTANT**: The `-v`/`--var` flag requires **fully-qualified symbols** (`namespace/var-name`), not bare var names. Using a bare name will throw `IllegalArgumentException: no conversion to symbol`.
 
-### Test Fixtures
+### with-testing-page
 
-The project provides shared `around` hooks in `com.blockether.spel.test-fixtures`:
-
-| Fixture | Binds | Scope |
-|---------|-------|-------|
-| `with-playwright` | `*pw*` | Shared Playwright instance |
-| `with-browser` | `*browser*` | Shared headless Chromium browser |
-| `with-traced-page` | `*page*` | **Default.** Fresh page per `it` block with tracing/HAR always enabled (auto-cleanup) |
-| `with-page` | `*page*` | Fresh page per `it` block (auto-cleanup, tracing only when Allure is active) |
-| `with-traced-page-opts` | `*page*` | Like `with-traced-page` but accepts context-opts map |
-| `with-page-opts` | `*page*` | Like `with-page` but accepts context-opts map |
-| `with-test-server` | `*test-server-url*` | Local HTTP test server |
-
-**Always use `with-traced-page` as the default** — it enables Playwright tracing and HAR capture on every test run, so traces are always available for debugging. Use `with-page` only if you explicitly want tracing disabled outside Allure.
-
-Use `{:context [with-playwright with-browser with-traced-page]}` on `describe` blocks. NEVER nest `with-playwright`/`with-browser`/`with-traced-page` manually inside `it` blocks.
-
-#### Custom Context Options
-
-To pass `Browser$NewContextOptions` (viewport, locale, color-scheme, storage-state, user-agent, etc.) use `with-page-opts` or `with-traced-page-opts`:
+All-in-one macro that creates the full Playwright stack (playwright → browser → context → page), binds the page, runs body, and tears everything down automatically. When Allure is active, tracing and HAR are enabled automatically.
 
 ```clojure
-;; Mobile viewport with French locale
-(describe "mobile view"
-  {:context [with-playwright with-browser
-             (with-traced-page-opts {:viewport {:width 375 :height 812}
-                                     :locale "fr-FR"})]}
-  (it "renders mobile layout"
-    (page/navigate *page* "https://example.com")
-    (expect (= "fr-FR" (page/evaluate *page* "navigator.language")))))
+;; Basic usage
+(core/with-testing-page [page]
+  (page/navigate page "https://example.com")
+  (expect (= "Example Domain" (page/title page))))
+
+;; With options (device, viewport, locale, etc.)
+(core/with-testing-page {:device :iphone-14} [page]
+  (page/navigate page "https://example.com")
+  (expect (= "fr-FR" (page/evaluate page "navigator.language"))))
+
+;; Desktop HD viewport with locale
+(core/with-testing-page {:viewport :desktop-hd :locale "fr-FR"} [page]
+  (page/navigate page "https://example.com"))
+
+;; Firefox with visible browser
+(core/with-testing-page {:browser-type :firefox :headless false} [page]
+  (page/navigate page "https://example.com"))
 
 ;; Load saved auth state
-(describe "authenticated tests"
-  {:context [with-playwright with-browser
-             (with-page-opts {:storage-state "auth.json"})]}
-  (it "is logged in"
-    (page/navigate *page* "https://app.example.com/dashboard")
-    (expect (nil? (assert/has-url (assert/assert-that *page*) "dashboard")))))
+(core/with-testing-page {:storage-state "auth.json"} [page]
+  (page/navigate page "https://app.example.com/dashboard"))
 ```
 
-All `*browser-context*` and `*browser-api*` bindings work the same as with the default fixtures.
+### with-testing-api
+
+All-in-one macro for API testing. Creates playwright → browser → context → API request context with automatic tracing.
+
+```clojure
+(core/with-testing-api {:base-url "https://api.example.com"} [ctx]
+  (api/get ctx "/users"))
+```
 
 ### Test Example
 
@@ -90,18 +85,18 @@ All `*browser-context*` and `*browser-api*` bindings work the same as with the d
 (ns my-app.test
   (:require
    [com.blockether.spel.assertions :as assert]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.locator :as locator]
    [com.blockether.spel.page :as page]
    [com.blockether.spel.roles :as role]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]
    [com.blockether.spel.allure :refer [defdescribe describe expect it]]))
 
 (defdescribe my-test
   (describe "example.com"
-    {:context [with-playwright with-browser with-traced-page]}
 
     (it "navigates and asserts"
-      (page/navigate *page* "https://example.com")
-      (expect (= "Example Domain" (page/title *page*)))
-      (expect (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Example Domain"))))))
+      (core/with-testing-page [page]
+        (page/navigate page "https://example.com")
+        (expect (= "Example Domain" (page/title page)))
+        (expect (nil? (assert/has-text (assert/assert-that (page/locator page "h1")) "Example Domain")))))))
 ```

--- a/resources/com/blockether/spel/templates/seed_test.clj.template
+++ b/resources/com/blockether/spel/templates/seed_test.clj.template
@@ -3,14 +3,14 @@
    This test tells agents how to configure the browser environment
    so that pages are already set up correctly."
   (:require
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.page :as page]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]
    [com.blockether.spel.allure :refer [defdescribe describe it expect]]))
 
 (defdescribe seed-test
   (describe "browser environment"
-    {:context [with-playwright with-browser with-traced-page]}
 
     (it "sets up and navigates to the application"
-      (page/navigate *page* "https://example.com")
-      (expect (= "Example Domain" (page/title *page*))))))
+      (core/with-testing-page [page]
+        (page/navigate page "https://example.com")
+        (expect (= "Example Domain" (page/title page)))))))

--- a/resources/com/blockether/spel/templates/seed_test_ct.clj.template
+++ b/resources/com/blockether/spel/templates/seed_test_ct.clj.template
@@ -3,17 +3,12 @@
    This test tells agents how to configure the browser environment
    so that pages are already set up correctly."
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures]]
-   [com.blockether.spel.page :as page]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]))
-
-;; Playwright + browser shared across all tests in this namespace
-(use-fixtures :once with-playwright with-browser)
-
-;; Fresh page (with tracing/HAR) for each test
-(use-fixtures :each with-traced-page)
+   [clojure.test :refer [deftest testing is]]
+   [com.blockether.spel.core :as core]
+   [com.blockether.spel.page :as page]))
 
 (deftest homepage-test
   (testing "loads successfully"
-    (page/navigate *page* "https://example.com")
-    (is (= "Example Domain" (page/title *page*)))))
+    (core/with-testing-page [page]
+      (page/navigate page "https://example.com")
+      (is (= "Example Domain" (page/title page))))))

--- a/resources/com/blockether/spel/templates/skills/spel/refs/ALLURE_REPORTING.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/ALLURE_REPORTING.md
@@ -60,7 +60,7 @@ Create step hierarchies for better test readability and failure debugging:
 
 | Option | Description |
 |--------|-------------|
-| `:screenshots?` | Take before/after screenshots (requires `*page*`, skipped when tracing) |
+| `:screenshots?` | Take before/after screenshots (requires page binding, skipped when tracing) |
 | `:http?` | Attach HTTP exchange markdown for APIResponse / browser Response |
 
 ```clojure
@@ -87,7 +87,7 @@ Create step hierarchies for better test readability and failure debugging:
 ## UI Steps
 
 UI steps automatically capture before/after screenshots. Equivalent to `(step name {:screenshots? true} body...)`.
-Requires `*page*` binding from test fixtures:
+Works with `core/with-testing-page` or test fixtures:
 
 ```clojure
 (allure/ui-step "Fill login form"
@@ -188,7 +188,7 @@ npx http-server allure-report -o -p 9999
 
 ## Trace Viewer Integration
 
-When using test fixtures (`with-page` / `with-traced-page`) or `with-testing-page` with Allure reporter active, Playwright tracing is automatically enabled.
+When using `with-testing-page` (recommended) or low-level fixtures (`with-page` / `with-traced-page`) with Allure reporter active, Playwright tracing is automatically enabled.
 
 ### What's Captured
 

--- a/resources/com/blockether/spel/templates/skills/spel/refs/ASSERTIONS_EVENTS.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/ASSERTIONS_EVENTS.md
@@ -85,8 +85,8 @@ Use `assert/assert-that` with a Locator to get LocatorAssertions.
 In test `it` blocks, ALWAYS wrap with `expect`:
 
 ```clojure
-(expect (nil? (assert/has-text (assert/assert-that (page/locator *page* "h1")) "Welcome")))
-(expect (nil? (assert/has-title (assert/assert-that *page*) "My Page")))
+(expect (nil? (assert/has-text (assert/assert-that (page/locator page "h1")) "Welcome")))
+(expect (nil? (assert/has-title (assert/assert-that page) "My Page")))
 ```
 
 ### Timeout Override

--- a/resources/com/blockether/spel/templates/skills/spel/refs/CODEGEN_CLI.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/CODEGEN_CLI.md
@@ -21,8 +21,8 @@ spel codegen --format=body recording.jsonl
 
 | Format | Output |
 |--------|--------|
-| `:test` (default) | Full test file with `defdescribe`/`it`/`expect` (from `spel.allure`), `with-playwright`/`with-browser`/`with-context`/`with-traced-page` |
-| `:script` | Standalone script with `require`/`import` + `with-playwright` chain |
+| `:test` (default) | Full test file with `defdescribe`/`it`/`expect` (from `spel.allure`) using `core/with-testing-page` |
+| `:script` | Standalone script with `require`/`import` + `with-testing-page` |
 | `:body` | Just action lines for pasting into existing code |
 
 ### Supported Actions

--- a/resources/com/blockether/spel/templates/skills/spel/refs/EVAL_GUIDE.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/EVAL_GUIDE.md
@@ -149,7 +149,7 @@ Every namespace below is pre-registered. No `require` or `import` needed.
 | `net/` | 46 | Network request/response inspection and route handling. Inspect headers, status, body. Mock or abort requests. |
 | `loc/` | 39 | Raw Locator operations with explicit Locator arg. Click, fill, hover, check, get attributes, evaluate JS on elements. |
 | `assert/` | 31 | Playwright assertion functions. `assert-that`, `has-text`, `is-visible`, `has-url`, `loc-not`, `page-not`. Takes assertion objects. |
-| `core/` | 29 fn + 4 macros | Browser lifecycle. `with-playwright`, `with-browser`, `with-context`, `with-page`, `with-testing-page`. |
+| `core/` | 29 fn + 4 macros | Browser lifecycle. `with-testing-page` (recommended), `with-testing-api`, plus low-level `with-playwright`, `with-browser`, `with-context`, `with-page`. |
 | `page/` | 42 | Raw Page operations with explicit page arg. Same functions as the library's `com.blockether.spel.page` namespace. |
 | `locator/` | (alias) | Alias of `loc/`. Both names work identically. |
 | `role/` | 82 constants | AriaRole constants: `role/button`, `role/link`, `role/heading`, `role/navigation`, `role/textbox`, etc. |

--- a/resources/com/blockether/spel/templates/skills/spel/refs/PAGE_LOCATORS.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/PAGE_LOCATORS.md
@@ -187,17 +187,18 @@ Use it in tests:
 
 (defdescribe login-test
   (describe "login flow"
-    
 
     (it "logs in with valid credentials"
-      (page/navigate page "https://app.example.com/login")
-      (login/login! page "alice" "secret123")
-      (expect (nil? (assert/has-url (assert/assert-that page) #".*dashboard.*"))))
+      (core/with-testing-page [page]
+        (page/navigate page "https://app.example.com/login")
+        (login/login! page "alice" "secret123")
+        (expect (nil? (assert/has-url (assert/assert-that page) #".*dashboard.*")))))
 
     (it "shows error for bad password"
-      (page/navigate page "https://app.example.com/login")
-      (login/login! page "alice" "wrong")
-      (expect (nil? (assert/is-visible (assert/assert-that (login/error-msg page))))))))
+      (core/with-testing-page [page]
+        (page/navigate page "https://app.example.com/login")
+        (login/login! page "alice" "wrong")
+        (expect (nil? (assert/is-visible (assert/assert-that (login/error-msg page)))))))))
 ```
 
 ## Composable Modules
@@ -336,10 +337,11 @@ All assertion functions return `nil` on success or an anomaly map on failure. Wr
 
 ```clojure
 (it "shows welcome heading"
-  (page/navigate page "https://app.example.com")
-  (let [h1 (page/get-by-role page role/heading {:level 1})]
-    (expect (nil? (assert/has-text (assert/assert-that h1) "Welcome")))
-    (expect (nil? (assert/is-visible (assert/assert-that h1))))))
+  (core/with-testing-page [page]
+    (page/navigate page "https://app.example.com")
+    (let [h1 (page/get-by-role page role/heading {:level 1})]
+      (expect (nil? (assert/has-text (assert/assert-that h1) "Welcome")))
+      (expect (nil? (assert/is-visible (assert/assert-that h1)))))))
 ```
 
 The `nil?` check works because assertion functions return `nil` on success and an anomaly map on failure.

--- a/resources/com/blockether/spel/templates/skills/spel/refs/PAGE_LOCATORS.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/PAGE_LOCATORS.md
@@ -182,22 +182,22 @@ Use it in tests:
    [my-app.pages.login :as login]
    [com.blockether.spel.page :as page]
    [com.blockether.spel.assertions :as assert]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.allure :refer [defdescribe describe expect it]]))
 
 (defdescribe login-test
   (describe "login flow"
-    {:context [with-playwright with-browser with-traced-page]}
+    
 
     (it "logs in with valid credentials"
-      (page/navigate *page* "https://app.example.com/login")
-      (login/login! *page* "alice" "secret123")
-      (expect (nil? (assert/has-url (assert/assert-that *page*) #".*dashboard.*"))))
+      (page/navigate page "https://app.example.com/login")
+      (login/login! page "alice" "secret123")
+      (expect (nil? (assert/has-url (assert/assert-that page) #".*dashboard.*"))))
 
     (it "shows error for bad password"
-      (page/navigate *page* "https://app.example.com/login")
-      (login/login! *page* "alice" "wrong")
-      (expect (nil? (assert/is-visible (assert/assert-that (login/error-msg *page*))))))))
+      (page/navigate page "https://app.example.com/login")
+      (login/login! page "alice" "wrong")
+      (expect (nil? (assert/is-visible (assert/assert-that (login/error-msg page))))))))
 ```
 
 ## Composable Modules
@@ -336,8 +336,8 @@ All assertion functions return `nil` on success or an anomaly map on failure. Wr
 
 ```clojure
 (it "shows welcome heading"
-  (page/navigate *page* "https://app.example.com")
-  (let [h1 (page/get-by-role *page* role/heading {:level 1})]
+  (page/navigate page "https://app.example.com")
+  (let [h1 (page/get-by-role page role/heading {:level 1})]
     (expect (nil? (assert/has-text (assert/assert-that h1) "Welcome")))
     (expect (nil? (assert/is-visible (assert/assert-that h1))))))
 ```

--- a/resources/com/blockether/spel/templates/skills/spel/refs/SNAPSHOT_TESTING.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/SNAPSHOT_TESTING.md
@@ -161,15 +161,15 @@ Generate HTML without a page: `(spel/report->html entries opts)` / `(annotate/re
   (:require
    [com.blockether.spel.assertions :as assert]
    [com.blockether.spel.page :as page]
-   [com.blockether.spel.test-fixtures :refer [*page* with-playwright with-browser with-traced-page]]
+   [com.blockether.spel.core :as core]
    [com.blockether.spel.allure :refer [defdescribe describe expect it]]))
 
 (defdescribe nav-snapshot-test
   (describe "navigation structure"
-    {:context [with-playwright with-browser with-traced-page]}
+    
     (it "matches expected ARIA structure"
-      (page/navigate *page* "https://example.com")
-      (let [la (assert/assert-that (page/locator *page* "body"))]
+      (page/navigate page "https://example.com")
+      (let [la (assert/assert-that (page/locator page "body"))]
         (expect (nil? (assert/matches-aria-snapshot la
                         "- heading \"Example Domain\"
                          - paragraph
@@ -195,10 +195,10 @@ Use snapshots during development to discover structure, then write ARIA assertio
 
 ```clojure
 (it "login form has expected structure"
-  (page/navigate *page* "https://example.com/login")
-  (let [{:keys [tree]} (snapshot/capture-snapshot *page*)]
+  (page/navigate page "https://example.com/login")
+  (let [{:keys [tree]} (snapshot/capture-snapshot page)]
     (println tree))  ;; inspect during development
-  (let [la (assert/assert-that (page/locator *page* "form"))]
+  (let [la (assert/assert-that (page/locator page "form"))]
     (assert/matches-aria-snapshot la
       "- form:
          - textbox \"Email\"
@@ -212,15 +212,15 @@ Use snapshots during development to discover structure, then write ARIA assertio
 
 ```clojure
 (it "has a submit button"
-  (page/navigate *page* "https://example.com/form")
-  (let [{:keys [refs]} (snapshot/capture-snapshot *page*)
+  (page/navigate page "https://example.com/form")
+  (let [{:keys [refs]} (snapshot/capture-snapshot page)
         submit-ref (->> refs
                      (some (fn [[id info]]
                              (when (and (= "button" (:role info))
                                         (= "Submit" (:name info)))
                                id))))]
     (expect (some? submit-ref))
-    (expect (locator/is-visible? (snapshot/resolve-ref *page* submit-ref)))))
+    (expect (locator/is-visible? (snapshot/resolve-ref page submit-ref)))))
 ```
 
 ### Multi-Step Workflow with Audit Trail

--- a/resources/com/blockether/spel/templates/skills/spel/refs/SNAPSHOT_TESTING.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/SNAPSHOT_TESTING.md
@@ -166,14 +166,15 @@ Generate HTML without a page: `(spel/report->html entries opts)` / `(annotate/re
 
 (defdescribe nav-snapshot-test
   (describe "navigation structure"
-    
+
     (it "matches expected ARIA structure"
-      (page/navigate page "https://example.com")
-      (let [la (assert/assert-that (page/locator page "body"))]
-        (expect (nil? (assert/matches-aria-snapshot la
-                        "- heading \"Example Domain\"
-                         - paragraph
-                         - link \"More information...\"")))))))
+      (core/with-testing-page [page]
+        (page/navigate page "https://example.com")
+        (let [la (assert/assert-that (page/locator page "body"))]
+          (expect (nil? (assert/matches-aria-snapshot la
+                          "- heading \"Example Domain\"
+                           - paragraph
+                           - link \"More information...\"\")))))))
 ```
 
 ### clojure.test
@@ -195,15 +196,16 @@ Use snapshots during development to discover structure, then write ARIA assertio
 
 ```clojure
 (it "login form has expected structure"
-  (page/navigate page "https://example.com/login")
-  (let [{:keys [tree]} (snapshot/capture-snapshot page)]
-    (println tree))  ;; inspect during development
-  (let [la (assert/assert-that (page/locator page "form"))]
-    (assert/matches-aria-snapshot la
-      "- form:
-         - textbox \"Email\"
-         - textbox \"Password\"
-         - button \"Sign in\"")))
+  (core/with-testing-page [page]
+    (page/navigate page "https://example.com/login")
+    (let [{:keys [tree]} (snapshot/capture-snapshot page)]
+      (println tree))  ;; inspect during development
+    (let [la (assert/assert-that (page/locator page "form"))]
+      (assert/matches-aria-snapshot la
+        "- form:
+           - textbox \"Email\"
+           - textbox \"Password\"
+           - button \"Sign in\""))))
 ```
 
 ## Ref Traversal Patterns
@@ -212,15 +214,16 @@ Use snapshots during development to discover structure, then write ARIA assertio
 
 ```clojure
 (it "has a submit button"
-  (page/navigate page "https://example.com/form")
-  (let [{:keys [refs]} (snapshot/capture-snapshot page)
-        submit-ref (->> refs
-                     (some (fn [[id info]]
-                             (when (and (= "button" (:role info))
-                                        (= "Submit" (:name info)))
-                               id))))]
-    (expect (some? submit-ref))
-    (expect (locator/is-visible? (snapshot/resolve-ref page submit-ref)))))
+  (core/with-testing-page [page]
+    (page/navigate page "https://example.com/form")
+    (let [{:keys [refs]} (snapshot/capture-snapshot page)
+          submit-ref (->> refs
+                       (some (fn [[id info]]
+                               (when (and (= "button" (:role info))
+                                          (= "Submit" (:name info)))
+                                 id))))]
+      (expect (some? submit-ref))
+      (expect (locator/is-visible? (snapshot/resolve-ref page submit-ref))))))
 ```
 
 ### Multi-Step Workflow with Audit Trail


### PR DESCRIPTION
## Summary

Migrates all teaching templates, seed tests, and agent prompts from the old fixture-based API (`with-playwright` + `with-browser` + `with-traced-page`) to the current `core/with-testing-page` and `core/with-testing-api` macros.

Closes #49
Linear: https://linear.app/blockether/issue/BLO-150

## Changes

### Fully rewritten (0 old patterns remaining):
- `flavours/lazytest/testing-conventions.md` - now teaches `with-testing-page`
- `flavours/clojure-test/testing-conventions.md` - now teaches `with-testing-page`
- `seed_test.clj.template` - uses `core/with-testing-page`
- `seed_test_ct.clj.template` - uses `core/with-testing-page`
- `agents/spel-test-generator.md` - all examples use `with-testing-page`
- `agents/spel-test-generator-ct.md` - all examples use `with-testing-page`

### Skill refs updated:
- `ALLURE_REPORTING.md` - updated fixture references
- `ASSERTIONS_EVENTS.md` - `*page*` → `page` in examples
- `CODEGEN_CLI.md` - output format descriptions updated
- `EVAL_GUIDE.md` - namespace table updated
- `PAGE_LOCATORS.md` - `*page*` → `page` in examples
- `SNAPSHOT_TESTING.md` - `*page*` → `page` in examples

### Not changed (API reference - documents existing low-level macros):
- `FULL_API.md`, `BROWSER_OPTIONS.md`, `PDF_STITCH_VIDEO.md`, `COMMON_PROBLEMS.md`, `PROFILES_AGENTS.md`

## Verification
```bash
# Teaching files should have 0 old patterns:
grep -c 'with-playwright\|with-browser\|with-traced-page\|\*page\*' \
  templates/flavours/*/testing-conventions.md \
  templates/seed_test*.clj.template \
  templates/agents/spel-test-generator*.md
# Expected: all 0
```