### PR TITLE
fix(ci): merge release + deploy-clojars into single job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     tags: ['v*']
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -128,47 +127,15 @@ jobs:
 
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    name: Create Release
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: List artifacts
-        run: find artifacts -type f | head -20
-
-      - name: Make Unix binaries executable
-        run: |
-          chmod +x artifacts/spel-linux-amd64/spel-linux-amd64 || true
-          chmod +x artifacts/spel-linux-arm64/spel-linux-arm64 || true
-          chmod +x artifacts/spel-macos-arm64/spel-macos-arm64 || true
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            artifacts/spel-linux-amd64/spel-linux-amd64
-            artifacts/spel-linux-arm64/spel-linux-arm64
-            artifacts/spel-macos-arm64/spel-macos-arm64
-            artifacts/spel-windows-amd64/spel-windows-amd64.exe
-
-  deploy-clojars:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    name: Deploy to Clojars
+    name: Release & Deploy to Clojars
 
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeLaGuardo/setup-clojure@13.5
         with:
@@ -185,6 +152,7 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-
 
+      # --- Deploy to Clojars ---
       - name: Build & Deploy to Clojars
         env:
           VERSION: ${{ github.ref_name }}
@@ -192,6 +160,7 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_DEPLOY_TOKEN }}
         run: clojure -T:build deploy
 
+      # --- Generate changelog ---
       - name: Generate changelog
         id: changelog
         run: |
@@ -204,12 +173,37 @@ jobs:
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" ${PREV_TAG}..${CURRENT_TAG})
           fi
 
-          echo "## What's Changed" > /tmp/release_body.md
-          echo "" >> /tmp/release_body.md
-          echo "$CHANGELOG" >> /tmp/release_body.md
-          echo "" >> /tmp/release_body.md
-          echo "**Full Changelog**: https://github.com/Blockether/spel/compare/${PREV_TAG}...${CURRENT_TAG}" >> /tmp/release_body.md
+          {
+            echo "## What's Changed"
+            echo ""
+            echo "$CHANGELOG"
+            echo ""
+            echo "**Full Changelog**: https://github.com/Blockether/spel/compare/${PREV_TAG}...${CURRENT_TAG}"
+          } > /tmp/release_body.md
 
+      # --- GitHub Release with binaries ---
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Make Unix binaries executable
+        run: |
+          chmod +x artifacts/spel-linux-amd64/spel-linux-amd64 || true
+          chmod +x artifacts/spel-linux-arm64/spel-linux-arm64 || true
+          chmod +x artifacts/spel-macos-arm64/spel-macos-arm64 || true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: /tmp/release_body.md
+          files: |
+            artifacts/spel-linux-amd64/spel-linux-amd64
+            artifacts/spel-linux-arm64/spel-linux-arm64
+            artifacts/spel-macos-arm64/spel-macos-arm64
+            artifacts/spel-windows-amd64/spel-windows-amd64.exe
+
+      # --- Update version files on main ---
       - name: Update README.md version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -267,5 +261,7 @@ jobs:
           git config user.name "blockether-deployer"
           git config user.email "contact@blockether.com"
           git add README.md CHANGELOG.md resources/SPEL_VERSION
-          git commit -m "release: update version files for ${{ github.ref_name }}, bump to next dev version" || echo "No changes to commit"
-          git push origin HEAD:main
+          git diff --cached --quiet && echo "No changes to commit" || {
+            git commit -m "release: update version files for ${{ github.ref_name }}, bump to next dev version"
+            git push origin main
+          }


### PR DESCRIPTION
## Problem

Release workflow had **two separate jobs** doing release work in parallel:
1. `release` job — GitHub Release with binaries + `generate_release_notes: true`
2. `deploy-clojars` job — Clojars deploy + changelog generation + version bump push

This caused:
- **Duplicate changelog**: `generate_release_notes` AND manual changelog = two 'Full Changelog' lines
- **403 on Clojars**: re-triggering the workflow tried to redeploy a non-snapshot version
- **Immutable release error**: softprops tried to overwrite existing release assets
- **Push rejected**: version bump commit was on detached HEAD (tag), not main branch

## Fix

Merged into **one sequential job**: `Release & Deploy to Clojars`

1. Deploy jar to Clojars
2. Generate changelog (single source)
3. Create GitHub Release with binaries + our changelog (`body_path`, no `generate_release_notes`)
4. Update README + CHANGELOG + SPEL_VERSION on main
5. Push version bump (checkout `ref: main`, not detached tag)

Also:
- Removed `workflow_dispatch` trigger (was source of double-runs)
- Push guarded by `git diff --cached --quiet` to avoid empty commits