### PR TITLE
feat(daemon): propagate Playwright error context instead of 'Unknown error'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ SCI Bindings:
 - Lambdas break `gen-docs` introspection, hide functions from FULL_API.md, and make debugging impossible
 - This applies to: `:bindings` map values, `make-ns-map` entries, `core/` namespace stubs
 
+Daemon Session Isolation:
+- ALWAYS use a named session when starting a daemon during development/testing — NEVER use the default "default" session
+- Generate a unique session name at task start: `SESSION=agent-$(date +%s)`
+- Use it on every spel command: `spel --session $SESSION open <url>`, `spel --session $SESSION click ...`
+- Teardown at end (or on error): `spel --session $SESSION close` — kills ONLY your session
+- NEVER run `spel close` without `--session` — it kills the default session which may belong to the user
+- Verify isolation: `spel session list` shows active sessions by name
+
 Paren Repair:
 - NEVER fix unbalanced parens/brackets by hand — always: `clj-paren-repair path/to/file.clj`
 

--- a/src/com/blockether/spel/cli.clj
+++ b/src/com/blockether/spel/cli.clj
@@ -2071,7 +2071,10 @@
     (let [{:keys [success data error]} response]
       (if success
         (println (json/write-json-str data :escape-slash false))
-        (println (json/write-json-str {:error (or error "Unknown error")} :escape-slash false))))
+        (let [err-map (cond-> {:error (or error "Unknown error")}
+                        (:call_log response) (assoc :call_log (:call_log response))
+                        (:selector response) (assoc :selector (:selector response)))]
+          (println (json/write-json-str err-map :escape-slash false)))))
     (let [{:keys [success data error]} response]
       (if success
         (cond

--- a/src/com/blockether/spel/daemon.clj
+++ b/src/com/blockether/spel/daemon.clj
@@ -455,26 +455,38 @@
 
 (defn- parse-playwright-error
   "Parses a Playwright error message to extract structured call log and selector.
-   Call log lines are extracted from between \"=== logs ===\" markers.
-   Selector is extracted from locator(\"...\") or getByRole/getByText/etc patterns.
+   Handles two Playwright log formats:
+     - Structured: lines between \"=== logs ===\" markers (locator timeout errors)
+     - Inline: lines after \"Call log:\" header (raw Playwright exceptions)
+   Selector extracted from locator(\"...\") or getByRole/getByText/etc patterns.
    Returns map with :call_log (vector of strings) and :selector (string or nil).
    Returns empty map when msg is nil or has no parseable structure."
   [msg]
   (when msg
-    (let [;; Extract call log between === logs === markers
-          ;; Playwright format: ===...=== logs ===...=== \n lines \n ===...===
+    (let [;; Format 1: structured === logs === block
           log-match (re-find #"(?s)={3,}\s*logs\s*={3,}\n(.*?)\n={3,}" msg)
-          call-log  (when-let [raw (second log-match)]
-                      (let [lines (->> (str/split-lines raw)
+          ;; Format 2: inline "Call log:" section (Playwright raw exception format)
+          call-log-raw (when-not log-match
+                         (second (re-find #"(?s)Call log:\n(.*)" msg)))
+          call-log  (cond
+                      log-match
+                      (let [lines (->> (str/split-lines (second log-match))
+                                    (mapv str/trim)
+                                    (filterv (complement str/blank?)))]
+                        (when (seq lines) lines))
+                      call-log-raw
+                      (let [lines (->> (str/split-lines call-log-raw)
+                                    ;; Strip leading dashes+spaces (format: "-   - msg")
+                                    (mapv #(str/replace % #"^[-\s]+" ""))
                                     (mapv str/trim)
                                     (filterv (complement str/blank?)))]
                         (when (seq lines) lines)))
-          ;; Extract selector from locator("...") pattern
-          sel-match (re-find #"locator\(\"([^\"]+)\"\)" msg)
+          ;; Greedy match handles inner escaped quotes: locator("[data-pw-ref=\"x\"]")
+          sel-match (second (re-find #"locator\(\"(.+)\"\)" msg))
           ;; Also try getByRole, getByText, etc.
-          get-by-match (when-not (second sel-match)
+          get-by-match (when-not sel-match
                          (re-find #"(getBy\w+)\(([^)]+)\)" msg))
-          selector  (or (second sel-match)
+          selector  (or sel-match
                       (when get-by-match
                         (str (second get-by-match) "(" (nth get-by-match 2) ")")))]
       (cond-> {}
@@ -1415,7 +1427,7 @@
               new-console (subvec @!console-messages console-before)
               new-errors  (subvec @!page-errors errors-before)]
           (if (anomaly/anomaly? result)
-            (cond-> {:error (::anomaly/message result)}
+            (cond-> (error-response (::anomaly/message result))
               (seq captured-stdout) (assoc :stdout captured-stdout)
               (seq captured-stderr) (assoc :stderr captured-stderr)
               (seq new-console)     (assoc :console new-console)
@@ -1439,13 +1451,11 @@
                 captured-stderr (str stderr-writer)
                 new-console (subvec @!console-messages console-before)
                 new-errors  (subvec @!page-errors errors-before)]
-            (throw (ex-info (.getMessage e)
-                     (cond-> {}
-                       (seq captured-stdout) (assoc :stdout captured-stdout)
-                       (seq captured-stderr) (assoc :stderr captured-stderr)
-                       (seq new-console)     (assoc :console new-console)
-                       (seq new-errors)      (assoc :page-errors new-errors))
-                     e))))))))
+            (cond-> (error-response (.getMessage e))
+              (seq captured-stdout) (assoc :stdout captured-stdout)
+              (seq captured-stderr) (assoc :stderr captured-stderr)
+              (seq new-console)     (assoc :console new-console)
+              (seq new-errors)      (assoc :page-errors new-errors))))))))
 
 ;; --- Close & Default ---
 
@@ -1507,12 +1517,17 @@
                           result
                           (map? result)
                           (some (fn [[_ v]] (when (anomaly/anomaly? v) v)) result))]
-          (if anomaly-v
+          (cond
+            ;; Handler returned an explicit failure map (e.g. sci_eval error path)
+            (and (map? result) (false? (:success result)))
+            (json/write-json-str result)
+            anomaly-v
             (let [msg  (::anomaly/message anomaly-v)
                   ex   (:playwright/exception anomaly-v)
                   hint (when ex (reflection-error-hint ex))
                   error-msg (or hint msg (when ex (.getMessage ^Throwable ex)) "Unknown error")]
               (json/write-json-str (error-response error-msg)))
+            :else
             (json/write-json-str {:success true :data result})))
         (catch Throwable e
           (let [hint (reflection-error-hint e)

--- a/src/com/blockether/spel/daemon.clj
+++ b/src/com/blockether/spel/daemon.clj
@@ -450,6 +450,63 @@
      (:tree snap))))
 
 ;; =============================================================================
+;; Error Helpers — used by command handlers and process-command
+;; =============================================================================
+
+(defn- parse-playwright-error
+  "Parses a Playwright error message to extract structured call log and selector.
+   Call log lines are extracted from between \"=== logs ===\" markers.
+   Selector is extracted from locator(\"...\") or getByRole/getByText/etc patterns.
+   Returns map with :call_log (vector of strings) and :selector (string or nil).
+   Returns empty map when msg is nil or has no parseable structure."
+  [msg]
+  (when msg
+    (let [;; Extract call log between === logs === markers
+          ;; Playwright format: ===...=== logs ===...=== \n lines \n ===...===
+          log-match (re-find #"(?s)={3,}\s*logs\s*={3,}\n(.*?)\n={3,}" msg)
+          call-log  (when-let [raw (second log-match)]
+                      (let [lines (->> (str/split-lines raw)
+                                    (mapv str/trim)
+                                    (filterv (complement str/blank?)))]
+                        (when (seq lines) lines)))
+          ;; Extract selector from locator("...") pattern
+          sel-match (re-find #"locator\(\"([^\"]+)\"\)" msg)
+          ;; Also try getByRole, getByText, etc.
+          get-by-match (when-not (second sel-match)
+                         (re-find #"(getBy\w+)\(([^)]+)\)" msg))
+          selector  (or (second sel-match)
+                      (when get-by-match
+                        (str (second get-by-match) "(" (nth get-by-match 2) ")")))]
+      (cond-> {}
+        call-log (assoc :call_log call-log)
+        selector (assoc :selector selector)))))
+
+(defn- error-response
+  "Creates a structured error response map from an error message string.
+   Parses Playwright error context (call_log, selector) when present.
+   Returns {:success false :error msg} with optional :call_log and :selector."
+  [^String msg]
+  (let [parsed (parse-playwright-error msg)]
+    (cond-> {:success false :error msg}
+      (:call_log parsed) (assoc :call_log (:call_log parsed))
+      (:selector parsed) (assoc :selector (:selector parsed)))))
+
+(defn- unwrap-anomaly!
+  "Checks if x is an anomaly map and re-throws the underlying error.
+   - Anomaly with :playwright/exception → re-throws the original exception.
+   - Anomaly without exception → throws ex-info with the anomaly message.
+   - Non-anomaly value → returns x unchanged.
+   Use this to wrap locator action results so errors propagate instead of
+   being silently discarded."
+  [x]
+  (if (anomaly/anomaly? x)
+    (if-let [ex (:playwright/exception x)]
+      (throw ex)
+      (throw (ex-info (or (::anomaly/message x) "Unknown error")
+               (dissoc x ::anomaly/message ::anomaly/category))))
+    x))
+
+;; =============================================================================
 ;; Command Handlers
 ;; =============================================================================
 
@@ -503,26 +560,26 @@
 
 (defmethod handle-cmd "click" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  (locator/click (resolve-selector selector))
+  (unwrap-anomaly! (locator/click (resolve-selector selector)))
   (let [tree (snapshot-after-action!)]
     {:clicked selector :snapshot tree}))
 
 (defmethod handle-cmd "fill" [_ {:strs [selector value]}]
   (ensure-page-loaded!)
-  (locator/fill (resolve-selector selector) value)
+  (unwrap-anomaly! (locator/fill (resolve-selector selector) value))
   (let [tree (snapshot-after-action!)]
     {:filled selector :snapshot tree}))
 
 (defmethod handle-cmd "type" [_ {:strs [selector text]}]
   (ensure-page-loaded!)
-  (locator/type-text (resolve-selector selector) text)
+  (unwrap-anomaly! (locator/type-text (resolve-selector selector) text))
   (let [tree (snapshot-after-action!)]
     {:typed selector :snapshot tree}))
 
 (defmethod handle-cmd "press" [_ {:strs [key selector]}]
   (ensure-page-loaded!)
   (if selector
-    (locator/press (resolve-selector selector) key)
+    (unwrap-anomaly! (locator/press (resolve-selector selector) key))
     (.press ^Keyboard (page/page-keyboard (pg)) key))
   (let [tree (snapshot-after-action!)]
     {:pressed key :snapshot tree}))
@@ -530,39 +587,39 @@
 (defmethod handle-cmd "hover" [_ {:strs [selector]}]
   (ensure-page-loaded!)
   (let [loc  (resolve-selector selector)
-        _    (locator/hover loc)
+        _    (unwrap-anomaly! (locator/hover loc))
         desc (describe-element loc)]
     (cond-> {:hovered selector}
       desc (assoc :desc desc))))
 
 (defmethod handle-cmd "check" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  (locator/check (resolve-selector selector))
+  (unwrap-anomaly! (locator/check (resolve-selector selector)))
   (let [tree (snapshot-after-action!)]
     {:checked selector :snapshot tree}))
 
 (defmethod handle-cmd "uncheck" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  (locator/uncheck (resolve-selector selector))
+  (unwrap-anomaly! (locator/uncheck (resolve-selector selector)))
   (let [tree (snapshot-after-action!)]
     {:unchecked selector :snapshot tree}))
 
 (defmethod handle-cmd "select" [_ {:strs [selector values]}]
   (ensure-page-loaded!)
-  (locator/select-option (resolve-selector selector) values)
+  (unwrap-anomaly! (locator/select-option (resolve-selector selector) values))
   (let [tree (snapshot-after-action!)]
     {:selected selector :snapshot tree}))
 
 (defmethod handle-cmd "dblclick" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  (locator/dblclick (resolve-selector selector))
+  (unwrap-anomaly! (locator/dblclick (resolve-selector selector)))
   (let [tree (snapshot-after-action!)]
     {:dblclicked selector :snapshot tree}))
 
 (defmethod handle-cmd "focus" [_ {:strs [selector]}]
   (ensure-page-loaded!)
   (let [loc  (resolve-selector selector)
-        _    (locator/focus loc)
+        _    (unwrap-anomaly! (locator/focus loc))
         desc (describe-element loc)]
     (cond-> {:focused selector}
       desc (assoc :desc desc))))
@@ -570,7 +627,7 @@
 (defmethod handle-cmd "clear" [_ {:strs [selector]}]
   (ensure-page-loaded!)
   (let [loc  (resolve-selector selector)
-        _    (locator/clear loc)
+        _    (unwrap-anomaly! (locator/clear loc))
         desc (describe-element loc)]
     (cond-> {:cleared selector}
       desc (assoc :desc desc))))
@@ -663,9 +720,10 @@
         sel       (get params "selector")
         smooth?   (get params "smooth" false)
         opts      {:amount amount :smooth? smooth?}
-        result    (if sel
-                    (locator/scroll (resolve-selector sel) direction opts)
-                    (page/scroll (pg) direction opts))
+        result    (unwrap-anomaly!
+                    (if sel
+                      (locator/scroll (resolve-selector sel) direction opts)
+                      (page/scroll (pg) direction opts)))
         tree      (snapshot-after-action!)]
     (assoc result :snapshot tree)))
 
@@ -690,27 +748,30 @@
 (defmethod handle-cmd "wait" [_ params]
   (cond
     (get params "text")
-    (do (page/wait-for-selector (pg) (str "text=" (get params "text")))
+    (do (unwrap-anomaly! (page/wait-for-selector (pg) (str "text=" (get params "text"))))
         {:found_text (get params "text")})
 
     (get params "url")
-    (do (page/wait-for-url (pg) (get params "url"))
+    (do (unwrap-anomaly! (page/wait-for-url (pg) (get params "url")))
         {:url (get params "url")})
 
     (get params "function")
-    (do (page/wait-for-function (pg) (get params "function"))
+    (do (unwrap-anomaly! (page/wait-for-function (pg) (get params "function")))
         {:function_completed true})
 
     (get params "selector")
-    (do (page/wait-for-selector (pg) (get params "selector"))
-        {:found (get params "selector")})
+    (let [sel (get params "selector")]
+      (if (ref? sel)
+        (unwrap-anomaly! (locator/wait-for (resolve-selector sel)))
+        (unwrap-anomaly! (page/wait-for-selector (pg) sel)))
+      {:found sel})
 
     (get params "state")
-    (do (page/wait-for-load-state (pg) (keyword (get params "state")))
+    (do (unwrap-anomaly! (page/wait-for-load-state (pg) (keyword (get params "state"))))
         {:state (get params "state")})
 
     (get params "timeout")
-    (do (page/wait-for-timeout (pg) (double (get params "timeout")))
+    (do (unwrap-anomaly! (page/wait-for-timeout (pg) (double (get params "timeout"))))
         {:waited (get params "timeout")})
 
     :else
@@ -755,36 +816,36 @@
 (defmethod handle-cmd "content" [_ params]
   (ensure-page-loaded!)
   (if-let [sel (get params "selector")]
-    {:html (locator/inner-html (resolve-selector sel))}
+    {:html (unwrap-anomaly! (locator/inner-html (resolve-selector sel)))}
     {:html (page/content (pg))}))
 
 (defmethod handle-cmd "get_text" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:text (locator/text-content (resolve-selector selector))})
+  {:text (unwrap-anomaly! (locator/text-content (resolve-selector selector)))})
 
 (defmethod handle-cmd "get_attribute" [_ {:strs [selector attribute]}]
   (ensure-page-loaded!)
-  {:value (locator/get-attribute (resolve-selector selector) attribute)})
+  {:value (unwrap-anomaly! (locator/get-attribute (resolve-selector selector) attribute))})
 
 (defmethod handle-cmd "is_visible" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:visible (locator/is-visible? (resolve-selector selector))})
+  {:visible (unwrap-anomaly! (locator/is-visible? (resolve-selector selector)))})
 
 (defmethod handle-cmd "is_enabled" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:enabled (locator/is-enabled? (resolve-selector selector))})
+  {:enabled (unwrap-anomaly! (locator/is-enabled? (resolve-selector selector)))})
 
 (defmethod handle-cmd "is_checked" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:checked (locator/is-checked? (resolve-selector selector))})
+  {:checked (unwrap-anomaly! (locator/is-checked? (resolve-selector selector)))})
 
 (defmethod handle-cmd "count" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:count (locator/count-elements (page/locator (pg) selector))})
+  {:count (unwrap-anomaly! (locator/count-elements (page/locator (pg) selector)))})
 
 (defmethod handle-cmd "bounding_box" [_ {:strs [selector]}]
   (ensure-page-loaded!)
-  {:box (locator/bounding-box (resolve-selector selector))})
+  {:box (unwrap-anomaly! (locator/bounding-box (resolve-selector selector)))})
 
 (defmethod handle-cmd "pdf" [_ {:strs [path]}]
   (ensure-page-loaded!)
@@ -1447,16 +1508,17 @@
                           (map? result)
                           (some (fn [[_ v]] (when (anomaly/anomaly? v) v)) result))]
           (if anomaly-v
-            (let [msg (::anomaly/message anomaly-v)
-                  ex  (:playwright/exception anomaly-v)
-                  hint (when ex (reflection-error-hint ex))]
-              (json/write-json-str {:success false
-                                    :error (or hint msg (when ex (.getMessage ^Throwable ex)) "Unknown error")}))
+            (let [msg  (::anomaly/message anomaly-v)
+                  ex   (:playwright/exception anomaly-v)
+                  hint (when ex (reflection-error-hint ex))
+                  error-msg (or hint msg (when ex (.getMessage ^Throwable ex)) "Unknown error")]
+              (json/write-json-str (error-response error-msg)))
             (json/write-json-str {:success true :data result})))
         (catch Throwable e
-          (let [msg  (or (reflection-error-hint e) (.getMessage e))
+          (let [hint (reflection-error-hint e)
+                msg  (or hint (.getMessage e))
                 data (ex-data e)]
-            (json/write-json-str (cond-> {:success false :error msg}
+            (json/write-json-str (cond-> (error-response msg)
                                    (:stdout data) (assoc :data {:stdout (:stdout data)
                                                                 :stderr (:stderr data)})))))))
     (catch Throwable e

--- a/src/com/blockether/spel/native.clj
+++ b/src/com/blockether/spel/native.clj
@@ -552,10 +552,18 @@
                 (println result-str))))
           ;; Error from daemon
           (do (vreset! exit-code 1)
-              (binding [*out* *err*]
-                (println (str "Error: " (or (get-in response [:data :error])
-                                          (:error response)
-                                          "Unknown error")))))))
+              (let [error-msg (or (get-in response [:data :error])
+                                (:error response)
+                                "Unknown error")]
+                (if (:json? global)
+                  ;; --json mode: structured error with call_log/selector
+                  (let [err-map (cond-> {:error error-msg}
+                                  (:call_log response) (assoc :call_log (:call_log response))
+                                  (:selector response) (assoc :selector (:selector response)))]
+                    (println (json/write-json-str err-map :escape-slash false)))
+                  ;; text mode: print full error message as-is
+                  (binding [*out* *err*]
+                    (println (str "Error: " error-msg))))))))
       (catch Exception e
         (vreset! exit-code 1)
         (binding [*out* *err*]

--- a/test-cli.sh
+++ b/test-cli.sh
@@ -1178,6 +1178,17 @@ assert_jq_contains "screenshot --crop-to-content → .path" "$OUT" '.path' 'test
 "$SPEL" set viewport 1280 720 >/dev/null 2>&1
 
 
+# =============================================================================
+# ERROR PROPAGATION (34)
+# =============================================================================
+section "Error Propagation (34)"
+
+# Click a non-existent ref — should fail with meaningful error, not "Unknown error"
+OUT=$("$SPEL" --json click @enonexistent 2>&1) || true
+assert_jq "click @enonexistent → has error" "$OUT" '.error != null'
+assert_jq "click @enonexistent → error != Unknown error" "$OUT" '.error != "Unknown error"'
+assert_jq_contains "click @enonexistent → error has context" "$OUT" '.error' 'not found'
+
 # SUMMARY
 # =============================================================================
 END_TIME=$(date +%s)

--- a/test/com/blockether/spel/cli_integration_test.clj
+++ b/test/com/blockether/spel/cli_integration_test.clj
@@ -1726,13 +1726,10 @@
         (expect (nil? (:stdout r)))
         (expect (nil? (:stderr r)))))
 
-    (it "preserves stdout on error via ex-data"
-      (let [threw (try (cmd "sci_eval" {"code" "(println \"before boom\") (throw (ex-info \"boom\" {}))"})
-                       nil
-                       (catch Exception e e))]
-        (expect (some? threw))
-        (let [data (ex-data threw)]
-          (expect (= "before boom\n" (str/replace (str (:stdout data)) "\r\n" "\n"))))))
+    (it "preserves stdout on error — included in error response map"
+      (let [result (cmd "sci_eval" {"code" "(println \"before boom\") (throw (ex-info \"boom\" {}))"})]
+        (expect (false? (:success result)))
+        (expect (= "before boom\n" (str/replace (str (:stdout result)) "\r\n" "\n")))))
 
     ;; --- Console/error auto-inclusion in sci_eval response ---
 
@@ -1771,14 +1768,10 @@
     (it "sci_eval includes console messages even on eval error"
       (cmd "sci_eval" {"code" (str "(spel/navigate \"" *test-server-url* "/test-page\")")})
       (cmd "console_clear" {})
-      (let [threw (try
-                    (cmd "sci_eval" {"code" "(do (spel/evaluate \"console.warn('before-error')\") (throw (ex-info \"boom\" {})))"})
-                    nil
-                    (catch Exception e e))]
-        (expect (some? threw))
-        (let [data (ex-data threw)]
-          (expect (some? (:console data)))
-          (expect (some #(= "before-error" (:text %)) (:console data))))))
+      (let [result (cmd "sci_eval" {"code" "(do (spel/evaluate \"console.warn('before-error')\") (throw (ex-info \"boom\" {})))"})]
+        (expect (false? (:success result)))
+        (expect (some? (:console result)))
+        (expect (some #(= "before-error" (:text %)) (:console result)))))
 
     ;; --- Help function ---
     ;; spel/help prints to stdout (captured as :stdout in daemon response)
@@ -2060,9 +2053,8 @@
                     "{\"name\":\"assertText\",\"selector\":\"h1\",\"signals\":[],\"text\":\"WRONG TEXT THAT DOES NOT EXIST ON PAGE\",\"substring\":true,\"pageGuid\":\"page@test\",\"pageAlias\":\"page\",\"framePath\":[]}")
             script (binding [codegen/*exit-on-error* false]
                      (codegen/jsonl-str->clojure jsonl {:format :script}))
-            threw? (try (cmd "sci_eval" {"code" script}) false
-                        (catch Exception _ true))]
-        (expect threw?)))
+            result (cmd "sci_eval" {"code" script})]
+        (expect (false? (:success result)))))
 
     (it "NEGATIVE: assertChecked on unchecked box throws in SCI eval"
       (let [jsonl (str "{\"browserName\":\"chromium\",\"launchOptions\":{\"headless\":true},\"contextOptions\":{}}\n"
@@ -2070,9 +2062,8 @@
                     "{\"name\":\"assertChecked\",\"selector\":\"#checkbox\",\"checked\":true,\"signals\":[],\"pageGuid\":\"page@test\",\"pageAlias\":\"page\",\"framePath\":[]}")
             script (binding [codegen/*exit-on-error* false]
                      (codegen/jsonl-str->clojure jsonl {:format :script}))
-            threw? (try (cmd "sci_eval" {"code" script}) false
-                        (catch Exception _ true))]
-        (expect threw?)))
+            result (cmd "sci_eval" {"code" script})]
+        (expect (false? (:success result)))))
 
     (it "NEGATIVE: assertValue with wrong value throws in SCI eval"
       (let [jsonl (str "{\"browserName\":\"chromium\",\"launchOptions\":{\"headless\":true},\"contextOptions\":{}}\n"
@@ -2080,9 +2071,8 @@
                     "{\"name\":\"assertValue\",\"selector\":\"#prefilled\",\"value\":\"COMPLETELY WRONG VALUE\",\"signals\":[],\"pageGuid\":\"page@test\",\"pageAlias\":\"page\",\"framePath\":[]}")
             script (binding [codegen/*exit-on-error* false]
                      (codegen/jsonl-str->clojure jsonl {:format :script}))
-            threw? (try (cmd "sci_eval" {"code" script}) false
-                        (catch Exception _ true))]
-        (expect threw?)))
+            result (cmd "sci_eval" {"code" script})]
+        (expect (false? (:success result)))))
 
     ;; --- Side-effect verification: prove the script actually mutated the browser ---
 

--- a/test/com/blockether/spel/daemon_test.clj
+++ b/test/com/blockether/spel/daemon_test.clj
@@ -373,4 +373,141 @@
           (finally
             (.delete f)))))))
 
+;; =============================================================================
+;; Unit Tests — parse-playwright-error (private)
+;; =============================================================================
+
+(defdescribe parse-playwright-error-test
+  "Unit tests for parse-playwright-error — extracts call log and selector from Playwright errors"
+
+  (describe "call log extraction"
+    (it "extracts call log lines between === logs === markers"
+      (let [msg (str "locator.click: Timeout 30000ms exceeded.\n"
+                  "=========================== logs ===========================\n"
+                  "waiting for locator(\"#missing\")\n"
+                  "  locator resolved to 0 elements\n"
+                  "============================================================")
+            result (#'sut/parse-playwright-error msg)]
+        (expect (= ["waiting for locator(\"#missing\")" "locator resolved to 0 elements"]
+                  (:call_log result)))))
+
+    (it "handles single-line call log"
+      (let [msg (str "Error: something\n"
+                  "=========================== logs ===========================\n"
+                  "waiting for locator(\"button\")\n"
+                  "============================================================")
+            result (#'sut/parse-playwright-error msg)]
+        (expect (= ["waiting for locator(\"button\")"] (:call_log result))))))
+
+  (describe "selector extraction"
+    (it "extracts selector from locator() pattern"
+      (let [msg "locator.click: Timeout 30000ms exceeded. locator(\"#submit-btn\") resolved to 0 elements"
+            result (#'sut/parse-playwright-error msg)]
+        (expect (= "#submit-btn" (:selector result)))))
+
+    (it "extracts getByRole pattern when no locator() present"
+      (let [msg "locator.click: getByRole(BUTTON, name=\"Submit\") resolved to 0 elements"
+            result (#'sut/parse-playwright-error msg)]
+        (expect (str/includes? (:selector result) "getByRole")))))
+
+  (describe "nil and empty input"
+    (it "returns nil for nil input"
+      (expect (nil? (#'sut/parse-playwright-error nil))))
+
+    (it "returns empty map for plain error without call log or selector"
+      (let [result (#'sut/parse-playwright-error "Some generic error")]
+        (expect (= {} result))))))
+
+;; =============================================================================
+;; Unit Tests — error-response (private)
+;; =============================================================================
+
+(defdescribe error-response-test
+  "Unit tests for error-response — creates structured error map from error message"
+
+  (describe "basic error"
+    (it "returns success=false with error message"
+      (let [result (#'sut/error-response "Something went wrong")]
+        (expect (false? (:success result)))
+        (expect (= "Something went wrong" (:error result)))))
+
+    (it "omits call_log and selector when not present"
+      (let [result (#'sut/error-response "Simple error")]
+        (expect (not (contains? result :call_log)))
+        (expect (not (contains? result :selector))))))
+
+  (describe "Playwright error with call_log and selector"
+    (it "includes call_log and selector when present in error message"
+      (let [msg (str "locator.click: Timeout 30000ms exceeded.\n"
+                  "=========================== logs ===========================\n"
+                  "waiting for locator(\"#btn\")\n"
+                  "  locator resolved to 0 elements\n"
+                  "============================================================")
+            result (#'sut/error-response msg)]
+        (expect (false? (:success result)))
+        (expect (= msg (:error result)))
+        (expect (vector? (:call_log result)))
+        (expect (= "#btn" (:selector result)))))))
+
+;; =============================================================================
+;; Unit Tests — unwrap-anomaly! (private)
+;; =============================================================================
+
+(defdescribe unwrap-anomaly-test
+  "Unit tests for unwrap-anomaly! — converts anomaly maps to thrown exceptions"
+
+  (describe "pass-through for non-anomaly values"
+    (it "returns a string unchanged"
+      (expect (= "hello" (#'sut/unwrap-anomaly! "hello"))))
+
+    (it "returns nil unchanged"
+      (expect (nil? (#'sut/unwrap-anomaly! nil))))
+
+    (it "returns a regular map unchanged"
+      (let [m {:foo "bar"}]
+        (expect (= m (#'sut/unwrap-anomaly! m))))))
+
+  (describe "re-throws original Playwright exception"
+    (it "throws the original exception when :playwright/exception is present"
+      (let [original-ex (Exception. "Playwright timeout")
+            anomaly-map (assoc (anomaly/anomaly ::anomaly/busy "Timeout 30000ms exceeded"
+                                 {:playwright/error-type :playwright.error/timeout})
+                          :playwright/exception original-ex)]
+        (try
+          (#'sut/unwrap-anomaly! anomaly-map)
+          (expect false "Should have thrown")
+          (catch Exception e
+            (expect (= original-ex e)))))))
+
+  (describe "throws ex-info for anomaly without exception"
+    (it "throws ex-info with anomaly message"
+      (let [anomaly-map (anomaly/anomaly ::anomaly/fault "Browser not found"
+                          {:playwright/error-type :playwright.error/exception})]
+        (try
+          (#'sut/unwrap-anomaly! anomaly-map)
+          (expect false "Should have thrown")
+          (catch clojure.lang.ExceptionInfo e
+            (expect (= "Browser not found" (.getMessage e)))))))))
+
+;; =============================================================================
+;; Unit Tests — process-command error propagation
+;; =============================================================================
+
+(defdescribe process-command-error-propagation-test
+  "Unit tests for error propagation through process-command"
+
+  (describe "unknown action"
+    (it "returns success with error field for unknown action"
+      (let [response (json/read-json
+                       (#'sut/process-command
+                        (json/write-json-str {"action" "nonexistent_action"})))]
+        (expect (true? (get response "success")))
+        (expect (str/includes? (get-in response ["data" "error"])
+                  "Unknown action")))))
+
+  (describe "error response has success=false"
+    (it "returns success=false for parse errors"
+      (let [response (json/read-json (#'sut/process-command "invalid json!!!"))]
+        (expect (false? (get response "success")))
+        (expect (str/includes? (get response "error") "Parse error"))))))
 


### PR DESCRIPTION
Closes #35

## Root Cause
Locator functions use the `safe` macro → anomaly maps. These were silently discarded in `do` blocks, so `process-command`'s anomaly detection never fired. Result: `Error: Unknown error`.

## Changes
- `parse-playwright-error` — extracts `:call_log` and `:selector` from Playwright error messages
- `error-response` — structured `{:success false :error ... :call_log [...] :selector "..."}`
- `unwrap-anomaly!` — converts anomaly maps → thrown exceptions so errors propagate
- All locator action handlers wrapped (click, fill, type, press, hover, check, uncheck, select, dblclick, focus, clear, scroll, wait, get_text, content, get_attribute, is_visible, is_enabled, is_checked, count, bounding_box)
- `wait @ref` fixed: now uses `resolve-selector + locator/wait-for` instead of raw ref string in `page/wait-for-selector`
- `--json` mode: `{"error": "...", "call_log": [...], "selector": "..."}`
- Text mode: full Playwright error printed as-is

## Tests
16 new unit tests + 3 bash assertions (section 34). All 1624 lazytest + 222 bash passing.