### PR TITLE
fix(ci): only run Allure Report on successful CI builds

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -23,7 +23,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     if: >-
-      github.event.workflow_run.conclusion != 'cancelled'
+      github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.head_repository.full_name == github.repository
 
     steps:


### PR DESCRIPTION
## Problem

The Allure Report workflow was failing when triggered by failed CI runs because the allure-results artifact may not exist.

## Solution

Changed the condition from `!= 'cancelled'` to `== 'success'` so the workflow only runs for successful CI builds, ensuring the allure-results artifact exists.

## Example Failure

- Run: https://github.com/Blockether/spel/actions/runs/22540471398
- Error: `Artifact not found for name: allure-results`

The workflow was triggered by a failed CI run (22540230129) from a different branch, which didn't have the artifact.