### PR TITLE
fix: video save-as - close page/context before saveAs

### DIFF
--- a/src/com/blockether/spel/core.clj
+++ b/src/com/blockether/spel/core.clj
@@ -670,10 +670,13 @@
     (str (.path v))))
 
 (defn video-save-as!
-  "Saves the video to the specified path. Context must be closed first.
+  "Saves the video to the specified path.
+   IMPORTANT: The page AND context must be closed first to finalize the video file.
+   Calling this on an open page will throw 'Page is not yet closed'.
+   Prefer using `sci-finish-video-recording` with `:save-as` opt instead.
 
    Params:
-   `page` - Page instance.
+   `page` - Page instance (must be closed).
    `path` - String destination path.
 
    Returns:

--- a/src/com/blockether/spel/sci_env.clj
+++ b/src/com/blockether/spel/sci_env.clj
@@ -57,7 +57,7 @@
     SameSiteAttribute ScreenshotType ServiceWorkerPolicy
     WaitForSelectorState WaitUntilState]
    [java.io File]
-   [java.nio.file Files LinkOption Path Paths]
+   [java.nio.file CopyOption Files LinkOption Path Paths StandardCopyOption]
    [java.nio.file.attribute FileAttribute]
    [java.util Base64]))
 
@@ -728,25 +728,32 @@
    Returns the video file path. Creates a new context/page without video.
 
    Opts:
-   :save-as - String. Copy video to this path before cleanup."
+   :save-as - String. Copy video to this path after finalization."
   ([] (sci-finish-video-recording {}))
   ([opts]
-   (let [pg      (require-page!)
+   (let [pg         (require-page!)
          video-path (core/video-path pg)
-         _       (when-let [save-path (:save-as opts)]
-                   (core/video-save-as! pg save-path))
-         ;; Close page first, then context to finalize video
-         _       (core/close-page! pg)
-         _       (when-let [c @!context] (core/close-context! c))
-         ;; Create fresh context without video
-         browser (require-browser!)
-         ctx     (core/new-context browser)
-         new-pg  (core/new-page-from-context ctx)]
+         save-path  (:save-as opts)
+         ;; 1. Close page + context first — this finalizes the video
+         _          (core/close-page! pg)
+         _          (when-let [c @!context] (core/close-context! c))
+         ;; 2. Now save-as is safe (file is finalized)
+         _          (when save-path
+                      (let [src (Path/of video-path (into-array String []))
+                            dst (Path/of save-path (into-array String []))]
+                        (Files/createDirectories (.getParent dst) (into-array FileAttribute []))
+                        (Files/copy src dst
+                          (into-array CopyOption
+                            [StandardCopyOption/REPLACE_EXISTING]))))
+         ;; 3. Create fresh context without video
+         browser    (require-browser!)
+         ctx        (core/new-context browser)
+         new-pg     (core/new-page-from-context ctx)]
      (when-let [timeout @!default-timeout]
        (page/set-default-timeout! new-pg timeout))
      (reset! !context ctx)
      (reset! !page new-pg)
-     {:status "stopped" :video-path video-path})))
+     {:status "stopped" :video-path (or save-path video-path)})))
 
 (defn sci-video-path
   "Returns the video file path for the current page, or nil if not recording."
@@ -2066,6 +2073,10 @@
                     'java.nio.file.LinkOption java.nio.file.LinkOption
                     'FileAttribute       java.nio.file.attribute.FileAttribute
                     'java.nio.file.attribute.FileAttribute java.nio.file.attribute.FileAttribute
+                    'CopyOption          java.nio.file.CopyOption
+                    'java.nio.file.CopyOption java.nio.file.CopyOption
+                    'StandardCopyOption   java.nio.file.StandardCopyOption
+                    'java.nio.file.StandardCopyOption java.nio.file.StandardCopyOption
                     ;; JDK utility classes
                     'Thread              java.lang.Thread
                     'java.lang.Thread    java.lang.Thread

--- a/test/com/blockether/spel/sci_eval_video_test.clj
+++ b/test/com/blockether/spel/sci_eval_video_test.clj
@@ -8,56 +8,95 @@
   "Video recording via SCI eval"
 
   (describe "start and finish video recording"
-    (it "records and produces a video file"
+            (it "records and produces a video file"
       ;; Reset SCI atoms
-      (reset! sut/!pw nil) (reset! sut/!browser nil)
-      (reset! sut/!context nil) (reset! sut/!page nil)
-      (reset! sut/!daemon-mode? false)
-      (let [ctx (sut/create-sci-ctx)]
-        (try
+                (reset! sut/!pw nil) (reset! sut/!browser nil)
+                (reset! sut/!context nil) (reset! sut/!page nil)
+                (reset! sut/!daemon-mode? false)
+                (let [ctx (sut/create-sci-ctx)]
+                  (try
           ;; Start browser
-          (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
 
           ;; Start video recording
-          (let [result (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")]
-            (expect (map? result))
-            (expect (= "recording" (:status result)))
-            (expect (= "test-videos-sci" (:video-dir result))))
+                    (let [result (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")]
+                      (expect (map? result))
+                      (expect (= "recording" (:status result)))
+                      (expect (= "test-videos-sci" (:video-dir result))))
 
           ;; Navigate to generate some video content
-          (sut/eval-string ctx "(spel/navigate \"https://example.com\")")
-          (sut/eval-string ctx "(spel/wait-for-timeout 500)")
+                    (sut/eval-string ctx "(spel/navigate \"https://example.com\")")
+                    (sut/eval-string ctx "(spel/wait-for-timeout 500)")
 
           ;; Check video path is available
-          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-            (expect (string? vpath))
-            (expect (.contains ^String vpath "test-videos-sci")))
+                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+                      (expect (string? vpath))
+                      (expect (.contains ^String vpath "test-videos-sci")))
 
           ;; Finish recording
-          (let [result (sut/eval-string ctx "(spel/finish-video-recording)")]
-            (expect (map? result))
-            (expect (= "stopped" (:status result)))
-            (expect (string? (:video-path result)))
+                    (let [result (sut/eval-string ctx "(spel/finish-video-recording)")]
+                      (expect (map? result))
+                      (expect (= "stopped" (:status result)))
+                      (expect (string? (:video-path result)))
             ;; Video file should exist after context close
-            (let [vpath (:video-path result)]
-              (expect (.exists (java.io.File. vpath)))))
+                      (let [vpath (:video-path result)]
+                        (expect (.exists (java.io.File. vpath)))))
 
           ;; Should have a new page without video
-          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-            (expect (nil? vpath)))
+                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+                      (expect (nil? vpath)))
 
-          (finally
-            (sut/eval-string ctx "(spel/stop!)"))))))
+                    (finally
+                      (sut/eval-string ctx "(spel/stop!)")))))))
+
+(defdescribe sci-video-save-as-test
+  "Video recording with :save-as via SCI eval"
+
+  (describe "finish-video-recording with :save-as"
+            (it "copies video to specified path and returns save-as path"
+                (reset! sut/!pw nil) (reset! sut/!browser nil)
+                (reset! sut/!context nil) (reset! sut/!page nil)
+                (reset! sut/!daemon-mode? false)
+                (let [ctx (sut/create-sci-ctx)
+                      save-path "test-videos-sci/save-as-copy.webm"]
+                  (try
+                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+
+          ;; Start recording
+                    (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")
+
+          ;; Generate content
+                    (sut/eval-string ctx "(spel/navigate \"https://example.com\")")
+                    (sut/eval-string ctx "(spel/wait-for-timeout 500)")
+
+          ;; Finish with :save-as — must not throw
+                    (let [result (sut/eval-string ctx
+                                                  (str "(spel/finish-video-recording {:save-as \"" save-path "\"})"))]
+                      (expect (map? result))
+                      (expect (= "stopped" (:status result)))
+            ;; :video-path should equal the save-as path
+                      (expect (= save-path (:video-path result)))
+            ;; File should exist at save-as location
+                      (expect (.exists (java.io.File. save-path))))
+
+                    (finally
+                      (sut/eval-string ctx "(spel/stop!)")
+            ;; Cleanup
+                      (let [f (java.io.File. save-path)]
+                        (when (.exists f) (.delete f)))))))))
+
+(defdescribe sci-video-path-nil-test
+  "Video path nil when not recording"
 
   (describe "video-path is nil without recording"
-    (it "returns nil when not recording"
-      (reset! sut/!pw nil) (reset! sut/!browser nil)
-      (reset! sut/!context nil) (reset! sut/!page nil)
-      (reset! sut/!daemon-mode? false)
-      (let [ctx (sut/create-sci-ctx)]
-        (try
-          (expect (= :started (sut/eval-string ctx "(spel/start!)")))
-          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-            (expect (nil? vpath)))
-          (finally
-            (sut/eval-string ctx "(spel/stop!)")))))))
+            (it "returns nil when not recording"
+                (reset! sut/!pw nil) (reset! sut/!browser nil)
+                (reset! sut/!context nil) (reset! sut/!page nil)
+                (reset! sut/!daemon-mode? false)
+                (let [ctx (sut/create-sci-ctx)]
+                  (try
+                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+                      (expect (nil? vpath)))
+                    (finally
+                      (sut/eval-string ctx "(spel/stop!)")))))))


### PR DESCRIPTION
Fixes #43

## Root cause
`sci-finish-video-recording` called `video-save-as!` before closing the page. Playwright requires the page (and context) to be closed first to finalize the video file.

## Fix
Moved save-as to after `close-page!` + `close-context!`. Uses `java.nio.file.Files/copy` with `REPLACE_EXISTING` instead of Playwright's `saveAs`.

## Changes
- **sci_env.clj**: Reordered `sci-finish-video-recording` — close page/context first, then `Files/copy` for save-as. Added `CopyOption`/`StandardCopyOption` imports + SCI class bindings.
- **core.clj**: Added docstring warning to `video-save-as!` — page must be closed first.
- **sci_eval_video_test.clj**: Added test for `finish-video-recording {:save-as ...}` — verifies no error, returned path matches, file exists.

## Acceptance criteria
- AC1: save-as succeeds without error
- AC2: no "Page is not yet closed" error
- AC3: function blocks until file written (Files/copy is synchronous)
- AC4: clear error if path not writable (IOException propagates)
- AC5: works from --eval and library API

## Tests
All 1656 tests pass (0 failures).