### PR TITLE
feat: add download CLI command

### DIFF
--- a/src/com/blockether/spel/cli.clj
+++ b/src/com/blockether/spel/cli.clj
@@ -341,6 +341,20 @@
       "  spel upload @ref photo.jpg"
       "  spel upload \"input[type=file]\" doc.pdf image.png"])
 
+   "download"
+   (str/join \newline
+     ["download - Click an element and save the triggered download"
+      ""
+      "Usage:"
+      "  spel download <selector> <save-path>"
+      ""
+      "Examples:"
+      "  spel download \"#export-btn\" ./report.csv"
+      "  spel download @e5 ./file.zip"
+      ""
+      "Flags:"
+      "  --timeout <ms>            Download timeout in milliseconds"])
+
    "screenshot"
    (str/join \newline
      ["screenshot - Take a screenshot"
@@ -1075,6 +1089,7 @@
      "  scrollintoview          Scroll element into view"
      "  drag                    Drag and drop"
      "  upload                  Upload files"
+     "  download                 Download file (click + save)"
      ""
      "Capture:"
      "  screenshot              Take screenshot"
@@ -1437,6 +1452,12 @@
           ;; Click
             "click"    {:action "click" :selector (first cmd-args)}
             "dblclick"  {:action "dblclick" :selector (first cmd-args)}
+
+          ;; Download
+            "download" (let [[selector save-path] cmd-args
+                             timeout-ms (:timeout flags)]
+                         (cond-> {:action "download" :selector selector :save-path save-path}
+                           timeout-ms (assoc :timeout-ms timeout-ms)))
 
           ;; Input
             "fill"     {:action "fill"

--- a/src/com/blockether/spel/daemon.clj
+++ b/src/com/blockether/spel/daemon.clj
@@ -739,6 +739,22 @@
   (let [tree (snapshot-after-action!)]
     {:clicked selector :snapshot tree}))
 
+
+(defmethod handle-cmd "download" [_ {:strs [selector save-path timeout-ms]}]
+  (ensure-page-loaded!)
+  (let [loc      (resolve-selector selector)
+        dl-opts  (when timeout-ms {:timeout (double timeout-ms)})
+        download (unwrap-anomaly!
+                   (if dl-opts
+                     (page/wait-for-download (pg) #(unwrap-anomaly! (locator/click loc)) dl-opts)
+                     (page/wait-for-download (pg) #(unwrap-anomaly! (locator/click loc)))))
+        filename (page/download-suggested-filename download)
+        _        (unwrap-anomaly! (page/download-save-as! download save-path))
+        size     (try (.length (java.io.File. ^String save-path)) (catch Exception _ -1))]
+    {:filename filename
+     :size     size
+     :path     save-path}))
+
 (defmethod handle-cmd "fill" [_ {:strs [selector value]}]
   (ensure-page-loaded!)
   (unwrap-anomaly! (locator/fill (resolve-selector selector) value))

--- a/test/com/blockether/spel/cli_test.clj
+++ b/test/com/blockether/spel/cli_test.clj
@@ -995,6 +995,35 @@
         (expect (= ["file1.txt" "file2.pdf"] (:files c)))))))
 
 ;; =============================================================================
+;; Download
+;; =============================================================================
+
+(defdescribe download-test
+  "Tests for download command"
+
+  (describe "download with CSS selector"
+    (it "parses download with selector and path"
+      (let [c (cmd ["download" "#export-btn" "./report.csv"])]
+        (expect (= "download" (:action c)))
+        (expect (= "#export-btn" (:selector c)))
+        (expect (= "./report.csv" (:save-path c))))))
+
+  (describe "download with ref"
+    (it "parses download with element ref"
+      (let [c (cmd ["download" "@e5" "./file.zip"])]
+        (expect (= "download" (:action c)))
+        (expect (= "@e5" (:selector c)))
+        (expect (= "./file.zip" (:save-path c))))))
+
+  (describe "download with timeout"
+    (it "parses download with --timeout flag"
+      (let [c (cmd ["download" "--timeout" "5000" "#btn" "./out.pdf"])]
+        (expect (= "download" (:action c)))
+        (expect (= "#btn" (:selector c)))
+        (expect (= "./out.pdf" (:save-path c)))
+        (expect (= 5000 (:timeout-ms c)))))))
+
+;; =============================================================================
 ;; Find (Semantic Locators)
 ;; =============================================================================
 
@@ -1136,7 +1165,7 @@
       (doseq [cmd-name ["open" "back" "forward" "reload" "snapshot" "click" "dblclick"
                         "fill" "type" "clear" "press" "keydown" "keyup" "hover" "mouse"
                         "check" "uncheck" "select" "focus" "scroll" "scrollintoview"
-                        "drag" "upload" "screenshot" "annotate" "unannotate" "pdf"
+                        "drag" "upload" "download" "screenshot" "annotate" "unannotate" "pdf"
                         "eval" "wait" "tab" "get" "is" "count" "bbox" "highlight"
                         "find" "set" "cookies" "storage" "network" "frame" "dialog"
                         "trace" "console" "errors" "state" "session" "connect"


### PR DESCRIPTION
Fixes #40

## Changes
- `spel download "#selector" ./path` — clicks element, waits for download, saves file
- `spel download @e5 ./file.zip` — works with element refs
- `--timeout <ms>` flag supported
- Output: `{filename, size, path}`
- `--json` output: `{"filename": "...", "size": 12345, "path": "..."}`

## Implementation
Uses existing `page/wait-for-download` + `page/download-save-as!` infrastructure. No new dependencies.

- **daemon.clj**: `handle-cmd "download"` — resolves selector, clicks to trigger download, waits via `page/wait-for-download`, saves via `page/download-save-as!`, returns filename/size/path
- **cli.clj**: Parser entry, command-help text, top-level help listing
- **cli_test.clj**: Parse tests for CSS selector, element ref, and `--timeout` flag

## Validation
- `make validate-safe-graal` ✅ (type-hinted `java.io.File.` to avoid reflection)
- `clojure -M:test` ✅ (1659 tests, 0 failures)

Closes BLO-157