### PR TITLE
docs: add one-shot LLM installation section + surface corporate CA setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ spel install   # install browsers
 spel version   # verify installation
 ```
 
+### One-Shot Installation (for LLM agents)
+
 <details>
-<summary>One-Shot Installation (for LLM agents)</summary>
+<summary>Full installation script</summary>
 
 A single copy-paste block that installs spel from scratch — designed for LLM agents:
 


### PR DESCRIPTION
Closes #47

Three changes:
1. **One-Shot Installation (for LLM agents)** — single copy-pasteable linear flow for platform detection, binary download, macOS quarantine removal, PATH setup, CA certs (Zscaler/Netskope), browser install and verify
2. **Corporate CA setup** surfaced prominently — no longer buried in collapsed section
3. **`spel install msedge`** added to post-install browser options

Minimal and focused — no other changes.