### PR TITLE
feat(cli): add --extension flag for Chrome extensions

### DIFF
--- a/src/com/blockether/spel/cli.clj
+++ b/src/com/blockether/spel/cli.clj
@@ -1183,6 +1183,7 @@
      "  --profile PATH          Chrome user data directory (persistent profile)"
      "  --channel NAME         Browser channel (e.g. \"chrome\", \"msedge\")"
      "  --no-stealth            Disable stealth mode (stealth is ON by default)"
+     "  --extension PATH        Load Chrome extension (repeatable, Chromium-only)"
      "  --timeout MS            Command timeout in milliseconds"
      "  --debug                 Enable debug logging"
      ""
@@ -1345,6 +1346,12 @@
 
                 (= "--no-stealth" arg)
                 (recur (rest args) (assoc flags :stealth false) remaining)
+
+                (= "--extension" arg)
+                (recur (drop 2 args) (update flags :extensions (fnil conj []) (second args)) remaining)
+
+                (str/starts-with? arg "--extension=")
+                (recur (rest args) (update flags :extensions (fnil conj []) (subs arg 12)) remaining)
 
                 :else
                 (recur (rest args) flags (conj remaining arg))))))

--- a/src/com/blockether/spel/daemon.clj
+++ b/src/com/blockether/spel/daemon.clj
@@ -296,7 +296,7 @@
           lines (if depth
                   (let [max-indent (* 2 (long depth))]
                     (filter (fn [line]
-                              (<= (count (take-while #{\  } line)) max-indent))
+                              (<= (count (take-while #{\ } line)) max-indent))
                       lines))
                   lines)
           lines (if flat
@@ -401,6 +401,16 @@
   (when-not (:browser @!state)
     (let [flags       (get @!state :launch-flags {})
           profile-dir (get flags "profile")
+          extensions  (get flags "extensions")
+          _           (when (seq extensions)
+                        (doseq [ext extensions]
+                          (when-not (.isDirectory (java.io.File. ^String ext))
+                            (throw (ex-info (str "Extension path does not exist or is not a directory: " ext)
+                                     {:extension-path ext}))))
+                        (binding [*out* *err*]
+                          (println (str "spel: Loading " (count extensions) " extension(s): "
+                                     (str/join ", " extensions)))
+                          (println "spel: Note: --extension is Chromium-only; extensions are ignored on Firefox/WebKit")))
           launch-opts (cond-> {:headless (:headless @!state)}
                         (get flags "executable-path") (assoc :executable-path (get flags "executable-path"))
                         (get flags "args")            (assoc :args (clojure.string/split (get flags "args") #","))
@@ -409,7 +419,12 @@
                         (get flags "cdp")             (assoc :cdp (get flags "cdp"))
                         (get flags "channel")          (assoc :channel (get flags "channel"))
                         (get flags "stealth")         (update :args (fnil into []) (stealth/stealth-args))
-                        (get flags "stealth")         (update :ignore-default-args (fnil into []) (stealth/stealth-ignore-default-args)))
+                        (get flags "stealth")         (update :ignore-default-args (fnil into []) (stealth/stealth-ignore-default-args))
+                        (seq extensions)
+                        (update :args (fnil conj [])
+                          (str "--load-extension=" (str/join "," extensions)))
+                        (seq extensions)
+                        (update :ignore-default-args (fnil conj []) "--disable-extensions"))
           ctx-opts    (cond-> {}
                         (get flags "user-agent")          (assoc :user-agent (get flags "user-agent"))
                         (get flags "ignore-https-errors")  (assoc :ignore-https-errors true)
@@ -770,7 +785,6 @@
   (unwrap-anomaly! (locator/click (resolve-selector selector)))
   (let [tree (snapshot-after-action!)]
     {:clicked selector :snapshot tree}))
-
 
 (defmethod handle-cmd "download" [_ {:strs [selector save-path timeout-ms]}]
   (ensure-page-loaded!)

--- a/src/com/blockether/spel/sci_env.clj
+++ b/src/com/blockether/spel/sci_env.clj
@@ -744,7 +744,7 @@
                         (Files/createDirectories (.getParent dst) (into-array FileAttribute []))
                         (Files/copy ^java.nio.file.Path src ^java.nio.file.Path dst
                           ^"[Ljava.nio.file.CopyOption;" (into-array CopyOption
-                            [StandardCopyOption/REPLACE_EXISTING]))))
+                                                           [StandardCopyOption/REPLACE_EXISTING]))))
          ;; 3. Create fresh context without video
          browser    (require-browser!)
          ctx        (core/new-context browser)

--- a/test/com/blockether/spel/cli_test.clj
+++ b/test/com/blockether/spel/cli_test.clj
@@ -799,7 +799,28 @@
 
     (it "supports --channel=value syntax"
       (let [f (flags ["--channel=msedge" "open" "http://x.com"])]
-        (expect (= "msedge" (:channel f)))))))
+        (expect (= "msedge" (:channel f))))))
+
+  (describe "--extension flag"
+    (it "sets single extension path"
+      (let [f (flags ["--extension" "/tmp/my-ext" "open" "http://x.com"])]
+        (expect (= ["/tmp/my-ext"] (:extensions f)))))
+
+    (it "accumulates multiple --extension flags"
+      (let [f (flags ["--extension" "/tmp/ext1" "--extension" "/tmp/ext2" "open" "http://x.com"])]
+        (expect (= ["/tmp/ext1" "/tmp/ext2"] (:extensions f)))))
+
+    (it "supports --extension=value syntax"
+      (let [f (flags ["--extension=/tmp/my-ext" "open" "http://x.com"])]
+        (expect (= ["/tmp/my-ext"] (:extensions f)))))
+
+    (it "accumulates mixed --extension and --extension= syntax"
+      (let [f (flags ["--extension" "./ext1" "--extension=./ext2" "open" "http://x.com"])]
+        (expect (= ["./ext1" "./ext2"] (:extensions f)))))
+
+    (it "defaults to nil when no --extension given"
+      (let [f (flags ["open" "http://x.com"])]
+        (expect (nil? (:extensions f)))))))
 
 ;; =============================================================================
 ;; Network Route (Bug Fix)

--- a/test/com/blockether/spel/sci_eval_video_test.clj
+++ b/test/com/blockether/spel/sci_eval_video_test.clj
@@ -8,95 +8,95 @@
   "Video recording via SCI eval"
 
   (describe "start and finish video recording"
-            (it "records and produces a video file"
+    (it "records and produces a video file"
       ;; Reset SCI atoms
-                (reset! sut/!pw nil) (reset! sut/!browser nil)
-                (reset! sut/!context nil) (reset! sut/!page nil)
-                (reset! sut/!daemon-mode? false)
-                (let [ctx (sut/create-sci-ctx)]
-                  (try
+      (reset! sut/!pw nil) (reset! sut/!browser nil)
+      (reset! sut/!context nil) (reset! sut/!page nil)
+      (reset! sut/!daemon-mode? false)
+      (let [ctx (sut/create-sci-ctx)]
+        (try
           ;; Start browser
-                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+          (expect (= :started (sut/eval-string ctx "(spel/start!)")))
 
           ;; Start video recording
-                    (let [result (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")]
-                      (expect (map? result))
-                      (expect (= "recording" (:status result)))
-                      (expect (= "test-videos-sci" (:video-dir result))))
+          (let [result (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")]
+            (expect (map? result))
+            (expect (= "recording" (:status result)))
+            (expect (= "test-videos-sci" (:video-dir result))))
 
           ;; Navigate to generate some video content
-                    (sut/eval-string ctx "(spel/navigate \"https://example.org\")")
-                    (sut/eval-string ctx "(spel/wait-for-timeout 500)")
+          (sut/eval-string ctx "(spel/navigate \"https://example.org\")")
+          (sut/eval-string ctx "(spel/wait-for-timeout 500)")
 
           ;; Check video path is available
-                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-                      (expect (string? vpath))
-                      (expect (.contains ^String vpath "test-videos-sci")))
+          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+            (expect (string? vpath))
+            (expect (.contains ^String vpath "test-videos-sci")))
 
           ;; Finish recording
-                    (let [result (sut/eval-string ctx "(spel/finish-video-recording)")]
-                      (expect (map? result))
-                      (expect (= "stopped" (:status result)))
-                      (expect (string? (:video-path result)))
+          (let [result (sut/eval-string ctx "(spel/finish-video-recording)")]
+            (expect (map? result))
+            (expect (= "stopped" (:status result)))
+            (expect (string? (:video-path result)))
             ;; Video file should exist after context close
-                      (let [vpath (:video-path result)]
-                        (expect (.exists (java.io.File. vpath)))))
+            (let [vpath (:video-path result)]
+              (expect (.exists (java.io.File. vpath)))))
 
           ;; Should have a new page without video
-                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-                      (expect (nil? vpath)))
+          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+            (expect (nil? vpath)))
 
-                    (finally
-                      (sut/eval-string ctx "(spel/stop!)")))))))
+          (finally
+            (sut/eval-string ctx "(spel/stop!)")))))))
 
 (defdescribe sci-video-save-as-test
   "Video recording with :save-as via SCI eval"
 
   (describe "finish-video-recording with :save-as"
-            (it "copies video to specified path and returns save-as path"
-                (reset! sut/!pw nil) (reset! sut/!browser nil)
-                (reset! sut/!context nil) (reset! sut/!page nil)
-                (reset! sut/!daemon-mode? false)
-                (let [ctx (sut/create-sci-ctx)
-                      save-path "test-videos-sci/save-as-copy.webm"]
-                  (try
-                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+    (it "copies video to specified path and returns save-as path"
+      (reset! sut/!pw nil) (reset! sut/!browser nil)
+      (reset! sut/!context nil) (reset! sut/!page nil)
+      (reset! sut/!daemon-mode? false)
+      (let [ctx (sut/create-sci-ctx)
+            save-path "test-videos-sci/save-as-copy.webm"]
+        (try
+          (expect (= :started (sut/eval-string ctx "(spel/start!)")))
 
           ;; Start recording
-                    (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")
+          (sut/eval-string ctx "(spel/start-video-recording {:video-dir \"test-videos-sci\"})")
 
           ;; Generate content
-                    (sut/eval-string ctx "(spel/navigate \"https://example.org\")")
-                    (sut/eval-string ctx "(spel/wait-for-timeout 500)")
+          (sut/eval-string ctx "(spel/navigate \"https://example.org\")")
+          (sut/eval-string ctx "(spel/wait-for-timeout 500)")
 
           ;; Finish with :save-as — must not throw
-                    (let [result (sut/eval-string ctx
-                                                  (str "(spel/finish-video-recording {:save-as \"" save-path "\"})"))]
-                      (expect (map? result))
-                      (expect (= "stopped" (:status result)))
+          (let [result (sut/eval-string ctx
+                         (str "(spel/finish-video-recording {:save-as \"" save-path "\"})"))]
+            (expect (map? result))
+            (expect (= "stopped" (:status result)))
             ;; :video-path should equal the save-as path
-                      (expect (= save-path (:video-path result)))
+            (expect (= save-path (:video-path result)))
             ;; File should exist at save-as location
-                      (expect (.exists (java.io.File. save-path))))
+            (expect (.exists (java.io.File. save-path))))
 
-                    (finally
-                      (sut/eval-string ctx "(spel/stop!)")
+          (finally
+            (sut/eval-string ctx "(spel/stop!)")
             ;; Cleanup
-                      (let [f (java.io.File. save-path)]
-                        (when (.exists f) (.delete f)))))))))
+            (let [f (java.io.File. save-path)]
+              (when (.exists f) (.delete f)))))))))
 
 (defdescribe sci-video-path-nil-test
   "Video path nil when not recording"
 
   (describe "video-path is nil without recording"
-            (it "returns nil when not recording"
-                (reset! sut/!pw nil) (reset! sut/!browser nil)
-                (reset! sut/!context nil) (reset! sut/!page nil)
-                (reset! sut/!daemon-mode? false)
-                (let [ctx (sut/create-sci-ctx)]
-                  (try
-                    (expect (= :started (sut/eval-string ctx "(spel/start!)")))
-                    (let [vpath (sut/eval-string ctx "(spel/video-path)")]
-                      (expect (nil? vpath)))
-                    (finally
-                      (sut/eval-string ctx "(spel/stop!)")))))))
+    (it "returns nil when not recording"
+      (reset! sut/!pw nil) (reset! sut/!browser nil)
+      (reset! sut/!context nil) (reset! sut/!page nil)
+      (reset! sut/!daemon-mode? false)
+      (let [ctx (sut/create-sci-ctx)]
+        (try
+          (expect (= :started (sut/eval-string ctx "(spel/start!)")))
+          (let [vpath (sut/eval-string ctx "(spel/video-path)")]
+            (expect (nil? vpath)))
+          (finally
+            (sut/eval-string ctx "(spel/stop!)")))))))


### PR DESCRIPTION
Closes #41

- `--extension /path/to/ext` loads extension on launch
- Multiple `--extension` flags supported
- Error if path does not exist
- Works with `--headed` and `--stealth`
- Chromium-only warning