### PR TITLE
feat(skill): add skill-version field and agent validation (BLO-161)

### DIFF
--- a/resources/com/blockether/spel/templates/skills/spel/SKILL.md
+++ b/resources/com/blockether/spel/templates/skills/spel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: spel
 description: "com.blockether.spel package - Clojure wrapper for Playwright 1.58.0. Browser automation, testing, assertions, codegen, CLI. Use when working with browser automation, E2E tests, Playwright API, or visual testing in Clojure."
+version: "{{version}}"
 license: Apache-2.0
 compatibility: opencode
 ---
@@ -8,6 +9,18 @@ compatibility: opencode
 # spel - Clojure Playwright Wrapper
 
 `com.blockether.spel` wraps Playwright Java 1.58.0 with idiomatic Clojure.
+
+## Version Check
+
+This skill was generated for spel **{{version}}**. Before proceeding, verify compatibility:
+
+```bash
+spel version
+```
+
+If the installed version does not match **{{version}}**:
+1. Show warning: **"spel skill is outdated (skill: {{version}}, installed: <actual version>)."**
+2. Propose reinitialization: **"Run `spel init-agents` to reinitialize the skill for the installed version."**
 
 ## Quick Reference
 

--- a/src/com/blockether/spel/init_agents.clj
+++ b/src/com/blockether/spel/init_agents.clj
@@ -223,12 +223,13 @@
 
 (defn- process-template
   "Processes a template by replacing placeholders.
-   Replaces {{ns}} and {{testing-conventions}} (flavour-specific testing section)."
+   Replaces {{ns}}, {{version}}, and {{testing-conventions}} (flavour-specific testing section)."
   [content ns-name flavour]
   (let [testing-section (or (read-flavour-section "testing-conventions.md" flavour)
                           "")]
     (-> content
       (str/replace "{{ns}}" ns-name)
+      (str/replace "{{version}}" @spel-version)
       (str/replace "{{testing-conventions}}" testing-section))))
 
 ;; =============================================================================


### PR DESCRIPTION
## Summary

Closes #67 | Linear: BLO-161

Adds versioned skill support so agents (Claude Code, opencode, etc.) can detect skill/binary version mismatches at session start.

## Changes

- `resources/.../SKILL.md` template: added `version: {{version}}` frontmatter + Version Check section
- `init_agents.clj`: `process-template` now substitutes `{{version}}` with actual spel version at `spel init-agents` time

## Behavior

When an agent loads the skill, it runs `spel version`, compares against `version` in frontmatter:
- Match: silent
- Mismatch: warns with skill vs installed version, proposes `spel init-agents` to reinitialize

No side effects — read-only check, safe degradation.