### PR TITLE
docs(skill): Chrome profile docs, profile vs state comparison, README (BLO-162)

### DIFF
--- a/resources/com/blockether/spel/templates/skills/spel/SKILL.md
+++ b/resources/com/blockether/spel/templates/skills/spel/SKILL.md
@@ -30,6 +30,11 @@ If the installed version does not match **{{version}}**:
 | `spel open <url>` | Open URL (stealth mode is ON by default) |
 | `spel state export --help` | State export help (cookies + localStorage) |
 | `spel state export --profile <path> -o auth.json` | Export Chrome cookies + localStorage to Playwright JSON |
+| `spel --profile <path> open <url>` | Open URL with persistent Chrome profile |
+| `spel --channel msedge --profile <path> open <url>` | Open with Edge profile |
+| `spel --load-state auth.json open <url>` | Open with exported state JSON |
+| `spel --load-state auth.json --eval 'script.clj'` | Run script with pre-loaded auth state |
+| `spel --channel msedge state export --profile <path>` | Export Edge cookies to Playwright JSON |
 | `spel codegen --help` | Codegen CLI help |
 | `spel init-agents --help` | Agent scaffolding help |
 | `spel init-agents --loop=opencode` | Scaffold E2E agents for OpenCode (default) |

--- a/resources/com/blockether/spel/templates/skills/spel/refs/PROFILES_AGENTS.md
+++ b/resources/com/blockether/spel/templates/skills/spel/refs/PROFILES_AGENTS.md
@@ -52,6 +52,54 @@ For lower-level control, use `core/launch-persistent-context` on the browser typ
 
 ---
 
+## Profile vs State: When to Use Which
+
+spel supports two auth approaches. Use this table to pick the right one:
+
+| | `--profile` (persistent context) | `state export` + `--load-state` (portable JSON) |
+|---|---|---|
+| **How it works** | Launches browser with a real Chrome/Edge user data dir | Exports cookies + localStorage to JSON, loads into fresh context |
+| **Auth persists** | Yes, automatically (in the profile dir) | Snapshot at export time — re-export to refresh |
+| **Cross-machine** | No (cookies encrypted with OS keychain) | Yes (decrypted portable JSON) |
+| **Extensions/prefs** | Yes (full Chrome profile) | No (cookies + localStorage only) |
+| **Concurrent use** | No (Chromium locks the dir) | Yes (read-only JSON, any number of browsers) |
+| **Edge support** | `--channel msedge --profile <path>` | `--channel msedge` on `state export` |
+| **Best for** | Local automation, dev workflows, interactive sessions | CI pipelines, cross-platform, agent automation, parallel runs |
+
+### Quick Decision
+
+- **Working locally on your machine?** Use `--profile`
+- **Running in CI or sharing auth across machines?** Use `state export` + `--load-state`
+- **Need concurrent browser sessions with same auth?** Use `--load-state` (profiles lock)
+- **Need extensions or browser preferences?** Use `--profile`
+
+### Edge / Other Chromium Browsers
+
+Use `--channel` to target non-default Chromium browsers:
+
+```bash
+# Persistent Edge profile
+spel --channel msedge --profile ~/.config/microsoft-edge/Default open https://example.com
+
+# Export Edge cookies
+spel state export --channel msedge --profile ~/.config/microsoft-edge/Default -o edge-auth.json
+
+# Use exported Edge cookies in any browser
+spel --load-state edge-auth.json open https://example.com
+```
+
+### Browser Profile Paths
+
+| OS | Chrome Default | Edge Default |
+|----|----------------|--------------|
+| macOS | `~/Library/Application Support/Google/Chrome/Default` | `~/Library/Application Support/Microsoft Edge/Default` |
+| Linux | `~/.config/google-chrome/Default` | `~/.config/microsoft-edge/Default` |
+| Windows | `%LOCALAPPDATA%\Google\Chrome\User Data\Default` | `%LOCALAPPDATA%\Microsoft\Edge\User Data\Default` |
+
+Profiles are numbered: `Default`, `Profile 1`, `Profile 2`, etc. Check `chrome://version` or `edge://version` to find the exact path.
+
+---
+
 ## Stealth Mode
 
 Stealth mode is **ON by default** for all CLI and `--eval` commands. Anti-detection patches hide Playwright's automation signals from bot-detection systems (Cloudflare, DataDome, PerimeterX, etc.). Based on [puppeteer-extra-plugin-stealth](https://github.com/AhmedIbrahim336/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth). Use `--no-stealth` to disable.


### PR DESCRIPTION
Closes #71 | Linear: BLO-162

## Summary

Documents the Chrome profile feature as a first-class capability:

### README.md
- Added 'Real Chrome Profiles' to feature list and as standalone section
- Shows macOS/Linux/Windows profile paths with examples
- Highlights state export for portable CI use

### SKILL.md Quick Reference
- Added `--profile`, `--load-state` commands

### PROFILES_AGENTS.md
- Added 'What You Get with --profile' — extensions, passwords, bookmarks, prefs, service workers
- Added Chrome profile paths table (macOS, Linux, Windows)
- Added Profile vs State comparison table with quick decision guide